### PR TITLE
remove symlinks for windows

### DIFF
--- a/tree-sitter/tree-sitter-ocaml/interface/corpus/module-items.txt
+++ b/tree-sitter/tree-sitter-ocaml/interface/corpus/module-items.txt
@@ -1,1 +1,0 @@
-../../ocaml/corpus/module-items.txt

--- a/tree-sitter/tree-sitter-toml/tree-sitter/CONTRIBUTING.md
+++ b/tree-sitter/tree-sitter-toml/tree-sitter/CONTRIBUTING.md
@@ -1,1 +1,0 @@
-docs/section-6-contributing.md

--- a/tree-sitter/tree-sitter-toml/tree-sitter/script/reproduce
+++ b/tree-sitter/tree-sitter-toml/tree-sitter/script/reproduce
@@ -1,1 +1,0 @@
-run-fuzzer

--- a/tree-sitter/tree-sitter-typescript/tsx/corpus/common
+++ b/tree-sitter/tree-sitter-typescript/tsx/corpus/common
@@ -1,1 +1,0 @@
-../../common/corpus

--- a/tree-sitter/tree-sitter-typescript/typescript/corpus/common
+++ b/tree-sitter/tree-sitter-typescript/typescript/corpus/common
@@ -1,1 +1,0 @@
-../../common/corpus

--- a/tree-sitter/tree-sitter/CONTRIBUTING.md
+++ b/tree-sitter/tree-sitter/CONTRIBUTING.md
@@ -1,1 +1,0 @@
-docs/section-6-contributing.md

--- a/tree-sitter/tree-sitter/script/reproduce
+++ b/tree-sitter/tree-sitter/script/reproduce
@@ -1,1 +1,0 @@
-run-fuzzer


### PR DESCRIPTION
currently if you try to build `zine-sample-site` on windows, zig will try to download zine and fail because of the symlinks:

```
Fetch Packages [3/1] Checkout... C:\git\zine-sample-site\build.zig.zon:6:20: error: unable to unpack packfile
            .url = "git+https://github.com/kristoff-it/zine.git#f2e6974344221bff95d465f7b037237d51f8b7d5",
                   ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
note: unable to create symlink from 'tree-sitter\tree-sitter-ocaml\interface\corpus\module-items.txt' to '../../ocaml/corpus/module-items.txt': AccessDenied
note: unable to create symlink from 'tree-sitter\tree-sitter-toml\tree-sitter\CONTRIBUTING.md' to 'docs/section-6-contributing.md': AccessDenied
note: unable to create symlink from 'tree-sitter\tree-sitter-toml\tree-sitter\script\reproduce' to 'run-fuzzer': AccessDenied
note: unable to create symlink from 'tree-sitter\tree-sitter-typescript\tsx\corpus\common' to '../../common/corpus': AccessDenied
note: unable to create symlink from 'tree-sitter\tree-sitter-typescript\typescript\corpus\common' to '../../common/corpus': AccessDenied
note: unable to create symlink from 'tree-sitter\tree-sitter\CONTRIBUTING.md' to 'docs/section-6-contributing.md': AccessDenied
note: unable to create symlink from 'tree-sitter\tree-sitter\script\reproduce' to 'run-fuzzer': AccessDenied
C:\git\zine-sample-site\build.zig.zon:6:20: error: unable to unpack git files: InvalidGitPack
            .url = "git+https://github.com/kristoff-it/zine.git#f2e6974344221bff95d465f7b037237d51f8b7d5",
```

I just removed the symlinks in this PR and now it works.  Not sure if these symlinks are needed for something else?