### PR TITLE
`linkLibC` for `docgen.zig`

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -161,6 +161,7 @@ pub fn build(b: *std.Build) !void {
         .target = target,
         .optimize = .Debug,
     });
+    docgen.linkLibC();
     docgen.root_module.addImport("datetime", datetime.module("zig-datetime"));
     b.installArtifact(docgen);
 }


### PR DESCRIPTION
You use the `c_allocator` to back the Arena but never link libc,
https://github.com/kristoff-it/zine/blob/89abc160002c4e3acdf21a04a2e459aa172dee25/zine/src/docgen.zig#L33