### PR TITLE
Fix assets being in subdirectories

### DIFF
--- a/zine/src/markdown-renderer.zig
+++ b/zine/src/markdown-renderer.zig
@@ -94,9 +94,10 @@ pub fn main() !void {
             // Skip non-local images
             if (std.mem.startsWith(u8, link, "http")) continue;
 
-            assets_in_dir.access(link, .{}) catch {
-                @panic("TODO: explain that a missing image has been found in a markdown file");
-            };
+            // Ensure any subdir exists
+            if (std.fs.path.dirname(link)) |dirname| {
+                try assets_out_dir.makePath(dirname);
+            }
 
             const path = try std.fs.path.join(arena, &.{ assets_in_path, link });
             try assets_dep_file.writer().print("{s} ", .{path});


### PR DESCRIPTION
Ensure that the output directory exists before attempting to copy. The copyFile function will not do this for you.

Also remove the access() check right before trying to use the file, per the documentation in std.fs.Dir.access, it's a bit pointless

> /// Be careful of Time-Of-Check-Time-Of-Use race conditions when using this function.
> /// For example, instead of testing if a file exists and then opening it, just
> /// open it and handle the error for file not found.

Fixes: https://github.com/kristoff-it/zine/issues/19