### PR TITLE
Update Zine to work with latest Zig

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -7,12 +7,12 @@
             .hash = "1220a2d62d1de13c424c79d281c273156083b5232199ff68780c146b9441015ab51c",
         },
         .mime = .{
-            .url = "git+https://github.com/andrewrk/mime.git#bf80e2e8b1d9413ddf9abe7d94537388b54c83ab",
-            .hash = "122074ce2f776dc9dc4a0d2588a5d76b97212a2c311ef8125d4aadffa4b84e5b8b3e",
+            .url = "git+https://github.com/andrewrk/mime.git#d340b5f611a224884eaf316d672121cccf2b0652",
+            .hash = "12208b3c98b4dcc88608e65889abc853f625a06edbb835da90d902bed1ade4da0ac8",
         },
         .ws = .{
-            .url = "git+https://github.com/karlseguin/websocket.zig.git#1f2c4a56c642dab52fe12cdda1bd3f56865d1f86",
-            .hash = "1220ce168e550f8904364acd0a72f5cafd40caa08a50ba83aac50b97ba700d7bcf20",
+            .url = "git+https://github.com/karlseguin/websocket.zig.git#c77f87d0e6548865636eb9781106a8be72e5755a",
+            .hash = "12208720b772330f309cfb48957f4152ee0930b716837d0c1d07fee2dea2f4dc712e",
         },
         .frontmatter = .{
             .path = "frontmatter",
@@ -29,8 +29,8 @@
             .hash = "122071f325c37101cb8a536f3274337f016369e43b7571a07e99c260a891f2a63199",
         },
         .@"flow-syntax" = .{
-            .url = "git+https://github.com/neurocyte/flow-syntax#106039c3aea0adc57613640daa9e15cd1ba0775c",
-            .hash = "122040f9537b7abea00d18ace2bbcfebb371040fd5f302c1292000714d0504fd238d",
+            .url = "git+https://github.com/neurocyte/flow-syntax#ca031a213e00eeb36b387706d1c07fc400affafc",
+            .hash = "1220512dcd20c4fc31a35ee2cbc5f5a8177effc5a5030c298795ac0c5528408c1083",
         },
     },
     .paths = .{"."},

--- a/super/build.zig.zon
+++ b/super/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "0.0.0",
     .dependencies = .{
         .@"tree-sitter" = .{
-            .url = "https://github.com/neurocyte/tree-sitter/releases/download/master-1593876627d5a40567b2b5468821736f3d1fb11b/source.tar.gz",
-            .hash = "1220fc22f6be9adc7e00682edf8a3c8487343dfbe53027f44224952f6a605cc520e5",
+            .url = "https://github.com/neurocyte/tree-sitter/releases/download/master-745bf25a45e46c686e7b6545714e467d312bb33e/source.tar.gz",
+            .hash = "1220daabcc33fe1d7fa625563827c47d32fc61a888b5adf3c494acfdeade0ca63d20",
         },
 
         .scripty = .{

--- a/super/src/sitter.zig
+++ b/super/src/sitter.zig
@@ -259,11 +259,10 @@ pub const Cursor = struct {
 pub const Element = struct {
     node: Node,
 
-    pub const voidTagMap = std.ComptimeStringMapWithEql(
+    pub const voidTagMap = std.StaticStringMapWithEql(
         void,
-        void_tags,
         std.ascii.eqlIgnoreCase,
-    );
+    ).initComptime(void_tags);
 
     pub fn startTag(self: Element) Tag {
         return self.node.childAt(0).?.toTag().?;


### PR DESCRIPTION
Hi @kristoff-it! Hope you don't mind the drive-by pull request, please let me know if there's anything I should do to improve it!

I was playing around with Zine and noticed it didn't work with the latest version of Zig. As a learning project, I tried digging into why, and ended up updating the dependencies, along with the code in one place (to accommodate [`ComptimeStringMap` being renamed to `StaticStringMap`](https://github.com/ziglang/zig/commit/8af59d1f98266bd70b3afb44d196bbd151cedf22)).

Note: getting Zine to work also depends on [this pull request by desttinghim](https://github.com/kristoff-it/cmark-gfm/pull/1) being merged in your fork of cmark-gfm!

I tried `zig build` and `zig build serve` with the zine-ssg.io repo, and everything seemed to work fine. I found that `zig build docgen` *didn't* work, but I don't think it's related to this pull request (I may be mistaken).