### PR TITLE
fix: reduce amount of layout step failures on windows

### DIFF
--- a/src/exes/layout/cache.zig
+++ b/src/exes/layout/cache.zig
@@ -657,7 +657,7 @@ fn loadPage(
                 hash.update(ml.code);
             },
         }
-        if (std.mem.endsWith(u8, md_rel_path, "/index.smd")) {
+        if (std.mem.endsWith(u8, md_rel_path, std.fs.path.sep_str ++ "index.smd")) {
             hash.update(std.fs.path.dirname(path_to_hash) orelse "");
         } else {
             hash.update(path_to_hash);


### PR DESCRIPTION
Avoids the panic "Failed to find a parent section match for a page" in `cache.zig` due to comparing two paths with different directory separators.

Partially addresses #58

This brings the number of succeeding steps from 206 to 331 (total 353).

I had to apply a few other workarounds to complete a build, please test that with this patch after `zig build serve` on `ziglang.org` you can still access all of the pages in the navbar ("Learn" gives me a 404 because it tries to access `http://127.0.0.1:1990/learn/index/` instead of `http://127.0.0.1:1990/learn/` but maybe that's related to my other changes that I cannot build without)