### PR TITLE
Adds missing colon to docs

### DIFF
--- a/src/context/Asset.zig
+++ b/src/context/Asset.zig
@@ -80,7 +80,7 @@ pub const Builtins = struct {
             \\Returns the size of an asset file in bytes.
         ;
         pub const examples =
-            \\<div text="$site.asset('foo.json').size()"></div>
+            \\<div :text="$site.asset('foo.json').size()"></div>
         ;
         pub fn call(
             self: Asset,
@@ -102,7 +102,7 @@ pub const Builtins = struct {
             \\Returns the raw contents of an asset.
         ;
         pub const examples =
-            \\<div text="$page.assets.file('foo.json').bytes()"></div>
+            \\<div :text="$page.assets.file('foo.json').bytes()"></div>
         ;
         pub fn call(
             self: Asset,
@@ -124,7 +124,7 @@ pub const Builtins = struct {
             \\Tries to parse the asset as a Ziggy document.
         ;
         pub const examples =
-            \\<div text="$page.assets.file('foo.ziggy').ziggy().get('bar')"></div>
+            \\<div :text="$page.assets.file('foo.ziggy').ziggy().get('bar')"></div>
         ;
         pub fn call(
             self: Asset,

--- a/src/context/Build.zig
+++ b/src/context/Build.zig
@@ -48,7 +48,7 @@ pub const Builtins = struct {
             \\Retuns a build-time asset (i.e. an asset generated through your 'build.zig' file) by name.
         ;
         pub const examples =
-            \\<div text="$build.asset('foo').bytes()"></div>
+            \\<div :text="$build.asset('foo').bytes()"></div>
         ;
         pub fn call(
             _: *const Build,

--- a/src/context/Map.zig
+++ b/src/context/Map.zig
@@ -109,7 +109,7 @@ pub const Builtins = struct {
         ;
         pub const examples =
             \\<div :if="$page.custom.get?('myValue')">
-            \\  <span text="$if"></span>
+            \\  <span :text="$if"></span>
             \\</div>
         ;
         pub fn call(

--- a/src/context/Map.zig
+++ b/src/context/Map.zig
@@ -108,7 +108,7 @@ pub const Builtins = struct {
             \\
         ;
         pub const examples =
-            \\<div if="$page.custom.get?('myValue')">
+            \\<div :if="$page.custom.get?('myValue')">
             \\  <span text="$if"></span>
             \\</div>
         ;
@@ -142,7 +142,7 @@ pub const Builtins = struct {
             \\
         ;
         pub const examples =
-            \\<div if="$page.custom.has('myValue')">Yep!</div>
+            \\<div :if="$page.custom.has('myValue')">Yep!</div>
         ;
         pub fn call(
             map: Map,

--- a/src/context/Page.zig
+++ b/src/context/Page.zig
@@ -392,7 +392,7 @@ pub const Builtins = struct {
             \\Returns the list of localized variants of the current page.
         ;
         pub const examples =
-            \\<div loop="$page.locales()"><a href="$loop.it.link()" text="$loop.it.title"></a></div>
+            \\<div :loop="$page.locales()"><a href="$loop.it.link()" text="$loop.it.title"></a></div>
         ;
         pub fn call(
             p: *const Page,

--- a/src/context/Page.zig
+++ b/src/context/Page.zig
@@ -795,7 +795,7 @@ pub const Builtins = struct {
             \\Renders the table of content.
         ;
         pub const examples =
-            \\<div html="$page.toc()"></div>
+            \\<div :html="$page.toc()"></div>
         ;
         pub fn call(
             p: *const Page,
@@ -844,7 +844,7 @@ pub const ContentSection = struct {
                 \\this function returns the heading as simple text.           
             ;
             pub const examples =
-                \\<div html="$loop.it.heading()"></div>
+                \\<div :html="$loop.it.heading()"></div>
             ;
             pub fn call(
                 cs: ContentSection,
@@ -888,7 +888,7 @@ pub const ContentSection = struct {
                 \\this function returns the heading as simple text.           
             ;
             pub const examples =
-                \\<div html="$loop.it.heading()"></div>
+                \\<div :html="$loop.it.heading()"></div>
             ;
             pub fn call(
                 cs: ContentSection,
@@ -921,7 +921,7 @@ pub const ContentSection = struct {
                 \\Renders the section.
             ;
             pub const examples =
-                \\<div html="$loop.it.html()"></div>
+                \\<div :html="$loop.it.html()"></div>
             ;
             pub fn call(
                 cs: ContentSection,

--- a/src/context/Page.zig
+++ b/src/context/Page.zig
@@ -115,7 +115,7 @@ pub const Alternative = struct {
             \\<ctx alt="$page.alternative('rss')"
             \\  <a href="$ctx.alt.link()" 
             \\     type="$ctx.alt.type" 
-            \\     text="$ctx.alt.name"
+            \\     :text="$ctx.alt.name"
             \\  ></a>
             \\</ctx>
             \\```
@@ -288,7 +288,7 @@ pub const Builtins = struct {
             \\
         ;
         pub const examples =
-            \\<div text="$page.locale('en-US').title"></div>
+            \\<div :text="$page.locale('en-US').title"></div>
         ;
         pub fn call(
             p: *const Page,
@@ -392,7 +392,7 @@ pub const Builtins = struct {
             \\Returns the list of localized variants of the current page.
         ;
         pub const examples =
-            \\<div :loop="$page.locales()"><a href="$loop.it.link()" text="$loop.it.title"></a></div>
+            \\<div :loop="$page.locales()"><a href="$loop.it.link()" :text="$loop.it.title"></a></div>
         ;
         pub fn call(
             p: *const Page,

--- a/src/context/Page.zig
+++ b/src/context/Page.zig
@@ -546,7 +546,7 @@ pub const Builtins = struct {
             \\Tries to return the page before the target one (sorted by date), to be used with an `if` attribute.
         ;
         pub const examples =
-            \\<div if="$page.prevPage()"></div>
+            \\<div :if="$page.prevPage()"></div>
         ;
 
         pub fn call(

--- a/src/context/Site.zig
+++ b/src/context/Site.zig
@@ -228,7 +228,7 @@ pub const Builtins = struct {
             \\To be used in conjunction with a `loop` attribute.
         ;
         pub const examples =
-            \\<ul loop="$site.pages('a', 'b', 'c')"><li text="$loop.it.title"></li></ul>
+            \\<ul :loop="$site.pages('a', 'b', 'c')"><li text="$loop.it.title"></li></ul>
         ;
         pub fn call(
             site: *const Site,

--- a/src/context/Site.zig
+++ b/src/context/Site.zig
@@ -85,7 +85,7 @@ pub const Builtins = struct {
             \\variant as defined in your `build.zig` file. 
         ;
         pub const examples =
-            \\<span text="$site.localeName()"></span>
+            \\<span :text="$site.localeName()"></span>
         ;
         pub fn call(
             p: *const Site,
@@ -118,7 +118,7 @@ pub const Builtins = struct {
             \\multilingual website.
         ;
         pub const examples =
-            \\<a href="$site.link()" text="$site.title"></a>
+            \\<a href="$site.link()" :text="$site.title"></a>
         ;
         pub fn call(
             p: *const Site,
@@ -228,7 +228,7 @@ pub const Builtins = struct {
             \\To be used in conjunction with a `loop` attribute.
         ;
         pub const examples =
-            \\<ul :loop="$site.pages('a', 'b', 'c')"><li text="$loop.it.title"></li></ul>
+            \\<ul :loop="$site.pages('a', 'b', 'c')"><li :text="$loop.it.title"></li></ul>
         ;
         pub fn call(
             site: *const Site,

--- a/src/context/String.zig
+++ b/src/context/String.zig
@@ -328,7 +328,7 @@ pub const Builtins = struct {
         pub const examples =
             \\<pre>
             \\  <code class="ziggy" 
-            \\        html="$page.custom.get('sample').syntaxHighLight('ziggy')"
+            \\        :html="$page.custom.get('sample').syntaxHighLight('ziggy')"
             \\  ></code>
             \\</pre>
         ;

--- a/src/context/primitive_builtins/Dynamic.zig
+++ b/src/context/primitive_builtins/Dynamic.zig
@@ -112,7 +112,7 @@ pub const @"get?" = struct {
         \\
     ;
     pub const examples =
-        \\<div if="$page.custom.get?('myValue')"><span var="$if"></span></div>
+        \\<div :if="$page.custom.get?('myValue')"><span var="$if"></span></div>
     ;
     pub fn call(
         dyn: ziggy.dynamic.Value,


### PR DESCRIPTION
I searched for instances of "if", "html", "loop", and "text" in the docs that were missing the colon prefix and fixed them. (There may still be other keywords missing colons that I missed.)