### PR TITLE
resolve percent encoding in URLs

### DIFF
--- a/src/exes/server/main.zig
+++ b/src/exes/server/main.zig
@@ -41,6 +41,11 @@ const Server = struct {
             @panic("TODO: check if '..' is fine");
         }
 
+        if (std.mem.indexOfScalar(u8, path, '%')) |_| {
+            const buffer = try arena.dupe(u8, path);
+            path = std.Uri.percentDecodeInPlace(buffer);
+        }
+
         if (std.mem.endsWith(u8, path, "/")) {
             path = try std.fmt.allocPrint(arena, "{s}{s}", .{
                 path,


### PR DESCRIPTION
This resolves #62 

I discovered quickly that the problem is that these German umlauts and other non-ASCII characters are converted to that weird %-encoding in the url by the browser(?). The server does not correctly resolve that when looking up the files. After looking at the table at [https://www.w3schools.com/tags/ref_urlencode.asp](https://www.w3schools.com/tags/ref_urlencode.asp) for a while and thinking about creating some lookup-table based on that, I decided that simply converting `"%AB"` into `"\xAB"` should do the trick.