### PR TITLE
Quote prereq names in layout depfile

### DIFF
--- a/src/exes/layout/DepWriter.zig
+++ b/src/exes/layout/DepWriter.zig
@@ -1,0 +1,17 @@
+const std = @import("std");
+
+const DepWriter = @This();
+
+w: std.io.AnyWriter,
+
+pub fn init(writer: std.io.AnyWriter) DepWriter {
+	return .{.w=writer};
+}
+
+pub fn writeTarget(dw: DepWriter, target: []const u8) !void {
+	try dw.w.print("\n{s}:", .{target});
+}
+
+pub fn writePrereq(dw: DepWriter, prereq: []const u8) !void {
+	try dw.w.print(" \"{s}\"", .{prereq});
+}

--- a/src/exes/layout/cache.zig
+++ b/src/exes/layout/cache.zig
@@ -4,6 +4,7 @@ const ziggy = @import("ziggy");
 const zine = @import("zine");
 const context = zine.context;
 const Allocator = std.mem.Allocator;
+const DepWriter = @import("DepWriter.zig");
 
 const log = std.log.scoped(.layout_cache);
 
@@ -19,7 +20,7 @@ pub fn initAll(
     _index_dir_path: []const u8,
     output_path_prefix: []const u8,
     locales: []const Locale,
-    _dep_writer: std.io.AnyWriter,
+    _dep_writer: DepWriter,
     asset_list_writer: std.io.AnyWriter,
 ) error{OutOfMemory}!void {
     gpa = _gpa;
@@ -61,7 +62,7 @@ pub fn initAll(
 }
 
 var gpa: Allocator = undefined;
-var dep_writer: std.io.AnyWriter = undefined;
+var dep_writer: DepWriter = undefined;
 var index_dir_path: []const u8 = undefined;
 
 pub const sites = struct {
@@ -266,7 +267,7 @@ const page_finder = struct {
 
                 log.debug("dep: '{s}'", .{index_path});
 
-                dep_writer.print("{s} ", .{index_path}) catch {
+                dep_writer.writePrereq(index_path) catch {
                     std.debug.panic(
                         "error while writing to dep file file: '{s}'",
                         .{index_path},
@@ -327,7 +328,7 @@ const page_finder = struct {
 
                     log.debug("dep: '{s}'", .{index_path});
 
-                    dep_writer.print("{s} ", .{index_path}) catch {
+                    dep_writer.writePrereq(index_path) catch {
                         std.debug.panic(
                             "error while writing to dep file file: '{s}'",
                             .{index_path},
@@ -421,7 +422,7 @@ const asset_finder = struct {
                 };
 
                 log.debug("dep: '{s}'", .{full_path});
-                dep_writer.print("{s} ", .{full_path}) catch {
+                dep_writer.writePrereq(full_path) catch {
                     std.debug.panic(
                         "error while writing to dep file file: '{s}'",
                         .{ref},
@@ -468,7 +469,7 @@ const asset_finder = struct {
         });
 
         log.debug("dep: '{s}'", .{full_path});
-        dep_writer.print("{s} ", .{full_path}) catch {
+        dep_writer.writePrereq(full_path) catch {
             std.debug.panic(
                 "error while writing to dep file file: '{s}'",
                 .{ref},
@@ -681,7 +682,7 @@ fn loadPage(
         ) catch @panic("i/o");
 
         log.debug("dep: '{s}'", .{ps_index_file_path});
-        dep_writer.print("{s} ", .{ps_index_file_path}) catch {
+        dep_writer.writePrereq(ps_index_file_path) catch {
             std.debug.panic(
                 "error while writing to dep file file: '{s}'",
                 .{ps_index_file_path},
@@ -710,7 +711,7 @@ fn loadPage(
         ) catch @panic("i/o");
 
         log.debug("dep: '{s}'", .{ps_file_path});
-        dep_writer.print("{s} ", .{ps_file_path}) catch {
+        dep_writer.writePrereq(ps_file_path) catch {
             std.debug.panic(
                 "error while writing to dep file file: '{s}'",
                 .{ps_file_path},
@@ -907,7 +908,7 @@ fn loadPage(
 
                 log.debug("dep: '{s}'", .{value.asset._meta.path});
 
-                dep_writer.print("{s} ", .{value.asset._meta.path}) catch {
+                dep_writer.writePrereq(value.asset._meta.path) catch {
                     std.debug.panic(
                         "error while writing to dep file file: '{s}'",
                         .{value.asset._meta.path},


### PR DESCRIPTION
The layout step was choking on paths with spaces in the depfile, so now all depfile paths are quoted. I could  have just added quotation marks to all existing print calls, but I figured it will be harder to screw it up again if we're not directly using the writer.