### PR TITLE
Option to include Drafts in Output

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -158,11 +158,17 @@ pub fn website(b: *std.Build, site: Site) void {
     // Setup debug flags if the user enabled Zine debug.
     const opts = zine.defaultZineOptions(b, site.debug);
 
+    const include_drafts = b.option(
+        bool,
+        "include-drafts",
+        "Include drafts in output",
+    ) orelse false;
+
     const website_step = b.step(
         "website",
         "Builds the website",
     );
-    zine.addWebsite(b, opts, website_step, site);
+    zine.addWebsite(b, opts, website_step, site, include_drafts);
 
     // Invoking the default step also builds the website
     b.getInstallStep().dependOn(website_step);
@@ -206,11 +212,17 @@ pub fn multilingualWebsite(b: *std.Build, multi: MultilingualSite) void {
     // Setup debug flags if the user enabled Zine debug.
     const opts = zine.defaultZineOptions(b, multi.debug);
 
+    const include_drafts = b.option(
+        bool,
+        "include-drafts",
+        "Include drafts in output",
+    ) orelse false;
+
     const website_step = b.step(
         "website",
         "Builds the website",
     );
-    zine.addMultilingualWebsite(b, website_step, multi, opts);
+    zine.addMultilingualWebsite(b, website_step, multi, opts, include_drafts);
 
     // Invoking the default step also builds the website
     b.getInstallStep().dependOn(website_step);
@@ -253,12 +265,14 @@ pub fn addWebsite(
     opts: ZineOptions,
     step: *std.Build.Step,
     site: Site,
+    include_drafts: bool,
 ) void {
     @import("build/content.zig").addWebsiteImpl(
         b,
         opts,
         step,
         .{ .site = site },
+        include_drafts,
     );
 }
 pub fn addMultilingualWebsite(
@@ -266,12 +280,14 @@ pub fn addMultilingualWebsite(
     step: *std.Build.Step,
     multi: MultilingualSite,
     opts: ZineOptions,
+    include_drafts: bool,
 ) void {
     @import("build/content.zig").addWebsiteImpl(
         b,
         opts,
         step,
         .{ .multilingual = multi },
+        include_drafts,
     );
 }
 

--- a/build.zig
+++ b/build.zig
@@ -188,6 +188,7 @@ pub fn website(b: *std.Build, site: Site) void {
         .website_step = website_step,
         .host = "localhost",
         .port = port,
+        .include_drafts = include_drafts,
         .input_dirs = &.{
             site.layouts_dir_path,
             site.content_dir_path,
@@ -295,6 +296,7 @@ pub const DevelopmentServerOptions = struct {
     website_step: *std.Build.Step,
     host: []const u8,
     port: u16 = 1990,
+    include_drafts: bool = false,
     input_dirs: []const []const u8,
 };
 pub fn addDevelopmentServer(
@@ -315,9 +317,10 @@ pub fn addDevelopmentServer(
     run_server.addArg(b.fmt("{d}", .{server_opts.port})); // #3
     run_server.addArg(server_opts.website_step.name); // #4
     run_server.addArg(@tagName(zine_opts.optimize)); // #5
+    run_server.addArg(b.fmt("{}", .{server_opts.include_drafts})); // #6
 
     for (server_opts.input_dirs) |dir| {
-        run_server.addArg(dir); // #6..
+        run_server.addArg(dir); // #7..
     }
 
     if (server_opts.website_step.id != .top_level) {

--- a/src/exes/server/main.zig
+++ b/src/exes/server/main.zig
@@ -222,8 +222,9 @@ pub fn main() !void {
     };
     const rebuild_step_name = args[4];
     const debug = std.mem.eql(u8, args[5], "Debug");
+    const include_drafts = std.mem.eql(u8, args[6], "true");
 
-    const input_dirs = args[6..];
+    const input_dirs = args[7..];
 
     // ensure the path exists. without this, an empty website that
     // doesn't generate a zig-out/ will cause the server to error out
@@ -240,6 +241,7 @@ pub fn main() !void {
         input_dirs,
         rebuild_step_name,
         debug,
+        include_drafts,
     );
 
     var server: Server = .{


### PR DESCRIPTION
When building a Site with zine, i marked some of my contents as drafts because they aren't finalized yet. But when writing the content, i wanted to be able to view it on the dev server output. So far i just marked them with `.draft = false` and when commiting i changed it back to true.

I added a build option in the standard website step to include drafts in the output. If there is a better/already built in way to do that, I would love to here about it and happily close this PR. 

Also I just scrambled this together, so if there are still stuff needed to consider or change, i'm also happy to do that.