### PR TITLE
Add Scripty function to generate SRI hash

### DIFF
--- a/src/context/Asset.zig
+++ b/src/context/Asset.zig
@@ -137,14 +137,14 @@ pub const Builtins = struct {
             };
 
             const sha384 = std.crypto.hash.sha2.Sha384;
-            var hashedData: [sha384.digest_length]u8 = undefined;
-            sha384.hash(data, &hashedData, .{});
+            var hashed_data: [std.crypto.hash.sha2.Sha384.digest_length]u8 = undefined;
+            sha384.hash(data, &hashed_data, .{});
 
             const base64 = std.base64.standard.Encoder;
-            const base64DataBuffer = try gpa.alloc(u8, base64.calcSize(hashedData.len));
-            const base64Data = base64.encode(base64DataBuffer, &hashedData);
+            var hashed_encoded_data: [base64.calcSize(hashed_data.len)]u8 = undefined;
+            _ = base64.encode(&hashed_encoded_data, &hashed_data);
 
-            return Value.from(gpa, try std.mem.concat(gpa, u8, &[_][]const u8{ "sha384-", base64Data }));
+            return Value.from(gpa, @as([]u8, "sha384-" ++ hashed_encoded_data));
         }
     };
 


### PR DESCRIPTION
Adds a Scripty function to generate a [Subresource Integrity](https://developer.mozilla.org/en-US/docs/Web/Security/Subresource_Integrity) hash for an asset.

Used like `$site.asset('foo.js').sriHash()`. I wrote an example site, which you can view at [shardion/zine-sri-test](https://github.com/shardion/zine-sri-test).

This is useful if you have JS or stylesheets which you update often, so you don't have to manually change the SRI hash every time.

The code seems to work correctly, but I'm unsure if it's good.