### PR TITLE
Windows support

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "0.0.0",
     .dependencies = .{
         .supermd = .{
-            .url = "git+https://github.com/kristoff-it/supermd#bc55d3bd06984c0701255a23a525feda3025cba9",
-            .hash = "12201aae1b7e5a9c73900b0e973c136c83207dfb94dfcff8658be737cbe037b495aa",
+            .url = "git+https://github.com/kristoff-it/supermd#e82051668fa0fdc4da065fcb245e98712b4454dc",
+            .hash = "1220c00c9be44387976c3da3fe991ae21692407f6c85c6b6903e239fe14654bcf0f4",
         },
         .scripty = .{
             .url = "git+https://github.com/kristoff-it/scripty#df8c11380f9e9bec34809f2242fb116d27cf39d6",

--- a/src/context/Page.zig
+++ b/src/context/Page.zig
@@ -9,6 +9,7 @@ const render = @import("../render.zig");
 const Signature = @import("doctypes.zig").Signature;
 const DateTime = @import("DateTime.zig");
 const context = @import("../context.zig");
+const join = @import("../root.zig").join;
 const Allocator = std.mem.Allocator;
 const Value = context.Value;
 const Optional = context.Optional;
@@ -698,9 +699,7 @@ pub const Builtins = struct {
                 false => p[0 .. p.len - ".smd".len],
             };
 
-            // TODO: support host url overrides
-
-            const result = try std.fs.path.join(gpa, &.{
+            const result = try join(gpa, &.{
                 "/",
                 self._meta.site._meta.url_path_prefix,
                 path,

--- a/src/context/Site.zig
+++ b/src/context/Site.zig
@@ -5,6 +5,7 @@ const Allocator = std.mem.Allocator;
 const scripty = @import("scripty");
 const utils = @import("utils.zig");
 const context = @import("../context.zig");
+const join = @import("../root.zig").join;
 const Signature = @import("doctypes.zig").Signature;
 const Value = context.Value;
 const Bool = context.Bool;
@@ -131,7 +132,7 @@ pub const Builtins = struct {
             };
             if (args.len != 0) return bad_arg;
 
-            const url = std.fs.path.join(gpa, &.{
+            const url = join(gpa, &.{
                 "/",
                 p._meta.url_path_prefix,
                 "/",

--- a/src/exes/layout.zig
+++ b/src/exes/layout.zig
@@ -5,6 +5,7 @@ const options = @import("options");
 const ziggy = @import("ziggy");
 const superhtml = @import("superhtml");
 const cache = @import("layout/cache.zig");
+const join = @import("../root.zig").join;
 const zine = @import("zine");
 const context = zine.context;
 const DepWriter = @import("layout/DepWriter.zig");
@@ -229,7 +230,7 @@ pub fn main() !void {
         error.WantSnippet => @panic("TODO: looad snippet"),
         error.WantTemplate => {
             const template_name = super_vm.wantedTemplateName();
-            const template_path = try std.fs.path.join(arena, &.{
+            const template_path = try join(arena, &.{
                 build_root_path,
                 templates_dir_path,
                 template_name,

--- a/src/exes/layout/cache.zig
+++ b/src/exes/layout/cache.zig
@@ -2,6 +2,7 @@ const std = @import("std");
 const supermd = @import("supermd");
 const ziggy = @import("ziggy");
 const zine = @import("zine");
+const join = zine.join;
 const context = zine.context;
 const Allocator = std.mem.Allocator;
 const DepWriter = @import("DepWriter.zig");
@@ -156,7 +157,7 @@ pub const pages = struct {
         index_in_section: ?usize,
         is_root_page: bool,
     ) error{ OutOfMemory, PageLoad }!*context.Page {
-        const full_path = try std.fs.path.join(gpa, &.{
+        const full_path = try join(gpa, &.{
             site._meta.content_dir_path,
             md_rel_path,
         });
@@ -187,7 +188,7 @@ const page_finder = struct {
 
     fn init(build_root_path: []const u8) error{OutOfMemory}!void {
         _ = build_root_path;
-        page_finder.page_index_dir_path = try std.fs.path.join(
+        page_finder.page_index_dir_path = try join(
             gpa,
             &.{
                 // build_root_path,
@@ -204,7 +205,7 @@ const page_finder = struct {
                 //  - foo/bar.smd
                 //  - foo/bar/index.smd
 
-                var md_path = try std.fs.path.join(gpa, &.{
+                var md_path = try join(gpa, &.{
                     ref.site._meta.content_dir_path,
                     ref.path,
                     "index.smd",
@@ -258,7 +259,7 @@ const page_finder = struct {
                     .simple => "",
                     .multi => |m| m.code,
                 };
-                const index_path = try std.fs.path.join(gpa, &.{
+                const index_path = try join(gpa, &.{
                     page_index_dir_path,
                     prefix,
                     page._meta.parent_section_path.?,
@@ -319,7 +320,7 @@ const page_finder = struct {
                         .simple => "",
                         .multi => |m| m.code,
                     };
-                    const index_path = try std.fs.path.join(gpa, &.{
+                    const index_path = try join(gpa, &.{
                         page_index_dir_path,
                         prefix,
                         path[0 .. path.len - "index.smd".len],
@@ -385,11 +386,11 @@ const asset_finder = struct {
         build_root_path: []const u8,
         _assets_dir_path: []const u8,
     ) error{OutOfMemory}!void {
-        asset_finder.assets_dir_path = try std.fs.path.join(gpa, &.{
+        asset_finder.assets_dir_path = try join(gpa, &.{
             build_root_path,
             _assets_dir_path,
         });
-        asset_finder.build_index_dir_path = try std.fs.path.join(
+        asset_finder.build_index_dir_path = try join(
             gpa,
             &.{ index_dir_path, "a" },
         );
@@ -409,7 +410,7 @@ const asset_finder = struct {
                 const entry_name = std.fmt.bufPrint(&buf, "{x}", .{
                     hash,
                 }) catch unreachable;
-                const full_path = try std.fs.path.join(gpa, &.{
+                const full_path = try join(gpa, &.{
                     asset_finder.build_index_dir_path,
                     entry_name,
                 });
@@ -468,7 +469,7 @@ const asset_finder = struct {
             });
         };
 
-        const full_path = try std.fs.path.join(gpa, &.{
+        const full_path = try join(gpa, &.{
             base_path,
             ref,
         });
@@ -524,7 +525,7 @@ const asset_collector = struct {
             else => "",
         };
 
-        const install_path = try std.fs.path.join(gpa, &.{
+        const install_path = try join(gpa, &.{
             asset_collector.output_path_prefix,
             maybe_page_rel_path,
             install_rel_path,
@@ -553,19 +554,19 @@ const asset_collector = struct {
                     gpa,
                     &.{},
                 );
-                break :blk std.fs.path.join(gpa, &.{
+                break :blk join(gpa, &.{
                     page_link.string.value,
                     ref,
                 });
             },
             // Links to site assets are absolute
-            .site => try std.fs.path.join(gpa, &.{
+            .site => try join(gpa, &.{
                 "/",
                 asset_collector.url_path_prefix,
                 ref,
             }),
             // Links to build assets are absolute
-            .build => |bip| try std.fs.path.join(gpa, &.{
+            .build => |bip| try join(gpa, &.{
                 "/",
                 asset_collector.url_path_prefix,
                 bip.?,
@@ -606,7 +607,7 @@ fn loadPage(
     });
     var time = std.time.Timer.start() catch unreachable;
 
-    const md_path = try std.fs.path.join(gpa, &.{
+    const md_path = try join(gpa, &.{
         site._meta.content_dir_path,
         md_rel_path,
     });
@@ -669,7 +670,7 @@ fn loadPage(
             hash.update(path_to_hash);
         }
 
-        const ps_index_file_path = try std.fs.path.join(gpa, &.{
+        const ps_index_file_path = try join(gpa, &.{
             index_dir_path,
             "ps",
             try std.fmt.allocPrint(gpa, "{x}", .{hash.final()}),
@@ -699,7 +700,7 @@ fn loadPage(
     const iis: ?usize = index_in_section orelse blk: {
         const ps_path = psp orelse break :blk null;
 
-        const ps_file_path = try std.fs.path.join(gpa, &.{
+        const ps_file_path = try join(gpa, &.{
             index_dir_path,
             "s",
 
@@ -759,7 +760,7 @@ fn loadPage(
     };
 
     if (page.translation_key) |tk| {
-        const tk_index_path = try std.fs.path.join(gpa, &.{ index_dir_path, "tk", tk });
+        const tk_index_path = try join(gpa, &.{ index_dir_path, "tk", tk });
         const tk_index = try std.fs.cwd().readFileAlloc(
             gpa,
             tk_index_path,
@@ -989,7 +990,7 @@ fn loadPage(
                                 );
 
                                 const end = md_rel_path.len - "index.smd".len;
-                                break :sub try std.fs.path.join(gpa, &.{
+                                break :sub try join(gpa, &.{
                                     md_rel_path[0..end],
                                     p.ref,
                                 });
@@ -1005,7 +1006,7 @@ fn loadPage(
                                     "the homepage has no siblings",
                                 );
 
-                                break :sibl try std.fs.path.join(gpa, &.{
+                                break :sibl try join(gpa, &.{
                                     ps_base,
                                     p.ref,
                                 });

--- a/src/exes/layout/cache.zig
+++ b/src/exes/layout/cache.zig
@@ -664,7 +664,7 @@ fn loadPage(
                 hash.update(ml.code);
             },
         }
-        if (std.mem.endsWith(u8, md_rel_path, std.fs.path.sep_str ++ "index.smd")) {
+        if (std.mem.endsWith(u8, md_rel_path, "/index.smd")) {
             hash.update(std.fs.path.dirname(path_to_hash) orelse "");
         } else {
             hash.update(path_to_hash);

--- a/src/exes/markdown-renderer.zig
+++ b/src/exes/markdown-renderer.zig
@@ -4,6 +4,7 @@ const scripty = @import("scripty");
 const ziggy = @import("ziggy");
 const zine = @import("zine");
 const supermd = @import("supermd");
+const join = @import("../root.zig").join;
 const context = zine.context;
 const hl = zine.highlight;
 const highlightCode = hl.highlightCode;
@@ -89,7 +90,7 @@ pub fn render(
                 .url => {},
                 .page => |link| {
                     const asset_path =
-                        try std.fs.path.join(arena, &.{
+                        try join(arena, &.{
                         md_asset_dir_path,
                         link,
                     });

--- a/src/root.zig
+++ b/src/root.zig
@@ -1,2 +1,63 @@
 pub const context = @import("context.zig");
 pub const highlight = @import("highlight.zig");
+
+const std = @import("std");
+
+pub fn join(allocator: std.mem.Allocator, paths: []const []const u8) ![]u8 {
+    const separator = '/';
+
+    // Find first non-empty path index.
+    const first_path_index = blk: {
+        for (paths, 0..) |path, index| {
+            if (path.len == 0) continue else break :blk index;
+        }
+
+        // All paths provided were empty, so return early.
+        return &[0]u8{};
+    };
+
+    // Calculate length needed for resulting joined path buffer.
+    const total_len = blk: {
+        var sum: usize = paths[first_path_index].len;
+        var prev_path = paths[first_path_index];
+        std.debug.assert(prev_path.len > 0);
+        var i: usize = first_path_index + 1;
+        while (i < paths.len) : (i += 1) {
+            const this_path = paths[i];
+            if (this_path.len == 0) continue;
+            const prev_sep = prev_path[prev_path.len - 1] == separator;
+            const this_sep = this_path[0] == separator;
+            sum += @intFromBool(!prev_sep and !this_sep);
+            sum += if (prev_sep and this_sep) this_path.len - 1 else this_path.len;
+            prev_path = this_path;
+        }
+
+        break :blk sum;
+    };
+
+    const buf = try allocator.alloc(u8, total_len);
+    errdefer allocator.free(buf);
+
+    @memcpy(buf[0..paths[first_path_index].len], paths[first_path_index]);
+    var buf_index: usize = paths[first_path_index].len;
+    var prev_path = paths[first_path_index];
+    std.debug.assert(prev_path.len > 0);
+    var i: usize = first_path_index + 1;
+    while (i < paths.len) : (i += 1) {
+        const this_path = paths[i];
+        if (this_path.len == 0) continue;
+        const prev_sep = prev_path[prev_path.len - 1] == separator;
+        const this_sep = this_path[0] == separator;
+        if (!prev_sep and !this_sep) {
+            buf[buf_index] = separator;
+            buf_index += 1;
+        }
+        const adjusted_path = if (prev_sep and this_sep) this_path[1..] else this_path;
+        @memcpy(buf[buf_index..][0..adjusted_path.len], adjusted_path);
+        buf_index += adjusted_path.len;
+        prev_path = this_path;
+    }
+
+    // No need for shrink since buf is exactly the correct size.
+    return buf;
+}


### PR DESCRIPTION
Asset tracking was having trouble with windows style path separators, but it turns out that you can just use unix separators everywhere and it just werks.

That said, the dev server doesn't always pick up new changes, which is very annoying.