### PR TITLE
Automatic width and height properties on images

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -3,8 +3,8 @@
     .version = "0.0.0",
     .dependencies = .{
         .supermd = .{
-            .url = "git+https://github.com/kristoff-it/supermd#a034ec48c8a01b26de50f479090716d3ed2152c9",
-            .hash = "122058e6f4ebd493d1c7f7c1e21549d2b2e5d9a1921dba758f3558d88a34a70384be",
+            .url = "git+https://github.com/kristoff-it/supermd#c47273684d3236881fdc9f90fbf66965389d88bd",
+            .hash = "1220f5265c5f99c621f3b2d822723ba1b79297b4c809fcee98c7d48947002458bf7c",
         },
         .scripty = .{
             .url = "git+https://github.com/kristoff-it/scripty#df8c11380f9e9bec34809f2242fb116d27cf39d6",
@@ -38,6 +38,10 @@
             .url = "git+https://github.com/kristoff-it/zig-afl-kit#f003bfe714f2964c90939fdc940d5993190a66ec",
             .hash = "1220f2d8402bb7bbc4786b9c0aad73910929ea209cbd3b063842371d68abfed33c1e",
             .lazy = true,
+        },
+        .wuffs = .{
+            .url = "git+https://github.com/allyourcodebase/wuffs#818c8ad6607dd5c1ee571362fdb9813b744ee548",
+            .hash = "1220e4ee09c4fa2d90a9cc7f34f14e04be55a779c84d486696fa9f9ab98ade35409d",
         },
     },
     .paths = .{"."},

--- a/build/tools.zig
+++ b/build/tools.zig
@@ -65,6 +65,7 @@ pub fn build(b: *std.Build) !void {
     const syntax = b.dependency("flow-syntax", mode);
     const ts = syntax.builder.dependency("tree-sitter", mode);
     const treez = ts.module("treez");
+    const wuffs = b.dependency("wuffs", mode);
 
     const zine = b.addModule("zine", .{
         .root_source_file = b.path("src/root.zig"),
@@ -97,6 +98,7 @@ pub fn build(b: *std.Build) !void {
     layout.root_module.addImport("zeit", zeit);
     layout.root_module.addImport("syntax", syntax.module("syntax"));
     layout.root_module.addImport("treez", treez);
+    layout.root_module.addImport("wuffs", wuffs.module("wuffs"));
     layout.linkLibrary(ts.artifact("tree-sitter"));
 
     b.installArtifact(layout);

--- a/src/render/html.zig
+++ b/src/render/html.zig
@@ -354,6 +354,7 @@ fn renderDirective(
                 if (directive.title) |t| try w.print(" title=\"{s}\"", .{t});
                 try w.print(" src=\"{s}\"", .{img.src.?.url});
                 if (img.alt) |alt| try w.print(" alt=\"{s}\"", .{alt});
+                if(img.size) |size| try w.print(" width=\"{d}\" height=\"{d}\"", .{size.w, size.h});
                 try w.print(">", .{});
                 if (img.linked) |l| if (l) try w.print("</a>", .{});
                 if (caption != null) try w.print("\n<figcaption>", .{});


### PR DESCRIPTION

Automatically adds image width and height properties to `$image.asset`s. This means while the site is loading, the image will already take up its full space and prevent the content shifting after the image loads. If it fails to determine the width, it will do nothing.

This may require modifications to your CSS to prevent horizontal squishing. If you override `width` or `max-width` in css, you must now also override height (to auto)

On my website, the change looked like this:

```diff
figure > img {
    margin: 1rem auto;
    max-width: 100vw;
+   height: auto;
}
```

PR depends on a supermd change unfortunately: https://github.com/kristoff-it/supermd/pull/8 . Open to better ideas on how to get the size from cache.zig to render/html.zig