### PR TITLE
Fix Windows reloader bugs

### DIFF
--- a/src/exes/server/Reloader.zig
+++ b/src/exes/server/Reloader.zig
@@ -168,6 +168,9 @@ pub fn onOutputChange(self: *Reloader, path: []const u8, name: []const u8) void 
             log.err("unable to generate ws message", .{});
             return;
         };
+        if (std.fs.path.sep != '/') {
+            std.mem.replaceScalar(u8, msg, std.fs.path.sep, '/');
+        }
 
         conn.write(msg) catch |err| {
             log.debug("error writing to websocket: {s}", .{

--- a/src/exes/server/watcher/zinereload.js
+++ b/src/exes/server/watcher/zinereload.js
@@ -95,17 +95,18 @@ function zineConnect() {
   socket.addEventListener("error", (event) => {
     log("error", event);
   });
+  return socket;
 }
 
-zineConnect();
+{
+  const socket = zineConnect();
 
-
-
-// Keep sending messages to circumvent an issue related to windows 
-// networking, see https://github.com/ziglang/zig/issues/14233
-function zinewin() {
+  // Keep sending messages to circumvent an issue related to windows
+  // networking, see https://github.com/ziglang/zig/issues/14233
+  function zinewin() {
     if (socket.readyState === WebSocket.OPEN) {
-        socket.send("https://github.com/ziglang/zig/issues/14233");
+      socket.send("https://github.com/ziglang/zig/issues/14233");
     }
+  }
+  setInterval(zinewin, 100);
 }
-setInterval(zinewin, 100);


### PR DESCRIPTION
The zinewin() function in zinereload.js now has the socket in scope and will not throw an exception about an undefined variable, and Reloader.zig normalizes path separators in reload messages.