### PR TITLE
feat: update flow-syntax

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -31,8 +31,8 @@
             .hash = "12204b653c90b503f89e2f1a73c4754b83fb7275c100c81872deaca12c9f17e334ec",
         },
         .@"flow-syntax" = .{
-            .url = "git+https://github.com/neurocyte/flow-syntax#d5b5da509350ef946b33cfb5c04ede68e288545b",
-            .hash = "122074a1a0a073213ae65d3f09863d6cb0622e1dbacf6a85e09a343e306c9da44c3b",
+            .url = "git+https://github.com/neurocyte/flow-syntax#9eb5c4c74daecec2a73654628c31b68d9908ec2e",
+            .hash = "122065eda677896d25cefbd042384a5b9236a3a4a3b58857ab66e22ade7777f8623f",
         },
         .@"zig-afl-kit" = .{
             .url = "git+https://github.com/kristoff-it/zig-afl-kit#f003bfe714f2964c90939fdc940d5993190a66ec",

--- a/src/highlight.zig
+++ b/src/highlight.zig
@@ -31,10 +31,11 @@ pub fn highlightCode(
     code: []const u8,
     writer: anytype,
 ) !void {
-    const lang = syntax.create_file_type(arena, code, lang_name) catch blk: {
+    const lang = syntax.create_file_type(arena, lang_name) catch blk: {
         const fake_filename = try std.fmt.allocPrint(arena, "file.{s}", .{lang_name});
         break :blk try syntax.create_guess_file_type(arena, "", fake_filename);
     };
+    try lang.refresh_full(code);
     defer lang.destroy();
 
     const tree = lang.tree orelse return;


### PR DESCRIPTION
Updating flow-syntax to latest commit, which slightly changes behaviour of public function `create_file_type`. Fixed by calling `refresh_full` explicitly.

The change in flow-syntax was here: https://github.com/neurocyte/flow-syntax/commit/b31fb25478ab3052b4dbfdeff686872683471c8a#diff-0e23ea69dfe11b8624839c93f049e040a20cc8aa33665576795eb8f8bc4108f7L41
And from my understanding, calling it directly won't change the behaviour of Zine if the call to `refresh_full` fails, assuming that it would have failed in the `catch` as well.

It also brings support for highlighting of the Gleam language:
![Screenshot 2024-11-15 at 09 51 38](https://github.com/user-attachments/assets/78c12418-0292-4626-ba89-aef3f79cb056)
