### PR TITLE
remove extra slash added to alternative

### DIFF
--- a/src/exes/layout/cache.zig
+++ b/src/exes/layout/cache.zig
@@ -969,7 +969,6 @@ fn loadPage(
                                             "/",
                                             site._meta.url_path_prefix,
                                             alt.output,
-                                            "/",
                                         });
                                         break :blk context.String.init(abs);
                                     }


### PR DESCRIPTION
The extra slash added to the alternative name causes the RSS link on the Zine devlog page to be broken. That link points to a file ( `.../log/index.xml` ) and not a directory.  (`.../log/index.xml/`). Some smart testing on whether the `/` is needed, but I IMO this could be inserted by hand if indeed a directory pointing URL is needed.