### PR TITLE
page: allow rendering pages loaded by scripty

### DIFF
--- a/src/context/Page.zig
+++ b/src/context/Page.zig
@@ -900,10 +900,6 @@ pub const Builtins = struct {
             var buf = std.ArrayList(u8).init(gpa);
             const ast = p._meta.ast orelse unreachable;
 
-            if (!p._meta.is_root) return .{
-                .err = "only the main page can be rendered for now, sorry!",
-            };
-
             try render.html(gpa, ast, ast.md.root, "", buf.writer());
             return String.init(try buf.toOwnedSlice());
         }


### PR DESCRIPTION
The `content` function of a `Page` was not allowed to be called if the
page was loaded by scripty. This meant that an RSS feed could not be
generated from a list of pages. The snippet from the website
(https://zine-ssg.io/docs/frequent/) would not work as a result of this
conditional if a user also wanted to publish the page content as part of
the RSS feed:

```html
<ctx :loop="$page.subpages()">
   <item>
    <title :text="$loop.it.title"></title>
    <link :text="$site.host_url.addPath($loop.it.link())"></link>
    <pubDate :text="$loop.it.date.formatHTTP()"></pubDate>
    <guid :text="$site.host_url.addPath($loop.it.link())"></guid>

    <!-- The following line will cause a scripty error -->
    <description :text="$loop.it.content()"></description>

   </item>
  </ctx>
```

Remove this conditional to allow pages loaded by scripty to be rendered.

Fixes: #107
