### PR TITLE
Print an Error message when Wuffs returns an error

### DIFF
--- a/src/exes/layout/cache.zig
+++ b/src/exes/layout/cache.zig
@@ -1188,7 +1188,9 @@ fn allocDecoder(
     return .{ decoder_raw, upcasted };
 }
 fn wrapErr(status: wuffs.wuffs_base__status) !void {
-    if (wuffs.wuffs_base__status__message(&status)) |_| {
+    if (wuffs.wuffs_base__status__message(&status)) |x| {
+        const y: [*:0]const u8 = x;
+        std.debug.print("Wuffs image parsing returned an error: \"{s}\", image sizes may not be emitted. Consider stripping Exif data. Continuing...\n", .{y});
         return error.WuffsError;
     }
 }


### PR DESCRIPTION
Related to https://github.com/kristoff-it/zine/pull/88

Wuffs is extremely strict with its parsing, so much so that it'll reject images that other tools accept or emit over minor issues. Some images I have get rejected even with no errors reported from tools like exiftool, until I strip out all the Exif data. In Zine, this manifests in the width and height attributes of your images not being emitted, silently.

I've fixed this by printing out a warning with a suggestion of what action the user can take. This is not the most ambitious of fixes, but it should help nudge people in the right direction should they run into this issue.

Aside: I think there needs to be an FAQ somewhere that goes something like:
> Q: Why do my images become stretched when when I apply a width/height?
> A: This is because Zine automatically applies [width and height attributes](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/img#height) to img tags. These tell the browser the intrinsic size of the image before it loads. Unfortunately and strangely, they also change the default CSS dimensions of the img from `auto` to the width and height values given, in px units. You will need to reset this somewhere with some CSS like this:
> ```
> img {
>    width: auto;
>    height: auto;
> }
> ```

But there doesn't seem to be a general FAQ area of the website, and I didn't want to intrude too much into your website design.