### PR TITLE
popOrNull has been renamed to pop

### DIFF
--- a/build/content.zig
+++ b/build/content.zig
@@ -446,7 +446,7 @@ pub fn scanVariant(
     }) catch unreachable;
 
     var root_index: ?Section.Page = null;
-    while (dir_stack.popOrNull()) |de| {
+    while (dir_stack.pop()) |de| {
         var dir_entry = de;
         log.debug("scanning dir '{s}'", .{dir_entry.path});
         defer {


### PR DESCRIPTION
Also relies on [scripty/pull/2](https://github.com/kristoff-it/scripty/pull/2), this should update the scripty version to point at that before merging.

Updates for latest Zig (`popOrNull` has been renamed to `pop`.)