### PR TITLE
Ignore footnotes ids when handlings content sections

### DIFF
--- a/tests/simple/snapshot/sections/index.html
+++ b/tests/simple/snapshot/sections/index.html
@@ -23,7 +23,7 @@
       <h2>-- SECTION END --</h2>
     
       <h2>-- SECTION BEGIN --</h2>
-      <div><div id="h3"><h3><a class="" href="#h3">H3</a></h3><p>Lorem Ipsum 3</p></div></div>
+      <div><div id="h3"><h3><a class="" href="#h3">H3</a></h3><p>Lorem Ipsum 3</p><p>This is a footnote<sup class="footnote-ref"><a href="#fn-1" id="fn-1-ref-1">1</a></sup></p></div></div>
       <h2>-- SECTION END --</h2>
     </div>
   </body>

--- a/tests/simple/src/content/sections.smd
+++ b/tests/simple/src/content/sections.smd
@@ -15,3 +15,6 @@ Lorem Ipsum 2
 ### [H3]($section.id('h3'))
 Lorem Ipsum 3
 
+This is a footnote[^1]
+
+[^1]: That should not break this page


### PR DESCRIPTION
Footnotes produce a reference that can be linked to and will show up in
the `ids` part of a page's Ast (see #92).

Footnotes have no directive attached to them, as their referenced
sections are added implicitly when they are processed by the parser.

The `contentSection` related methods did assume that all nodes in `ids`
are proper sections, so having footnotes would break layouts that use
such an API, e.g. `$page.contentSections()`.

This commit updates those implementations to expect nodes to not
necessarily have a directive.

Additionally, the logic of `hasContentSection` is aligned with the
behavior of `contentSection(id)`, so that returning a true value will
not trigger an error when getting the content section.
This would have been possible before id the node with that name is not a
`section`, however it might have been that, in practice, this was never
the case.

I added a footnote to the sections snapshot to show that rendering this
page does no longer break.

I also considered a change in supermd that would not include footnotes
in the `ids` list, but that would have lost the ability to #ref-link
to footnotes outside of the footnote rendering itself.
