### PR TITLE
Fix devserver hang when browser's request headers > 1024 bytes:

### DIFF
--- a/src/exes/server/main.zig
+++ b/src/exes/server/main.zig
@@ -17,6 +17,8 @@ pub const std_options: std.Options = .{
 var general_purpose_allocator = std.heap.GeneralPurposeAllocator(.{}){};
 
 const Server = struct {
+    pub const MAX_CONN_HEADER_SIZE: usize = 8 * 1024;
+
     watcher: *Reloader,
     public_dir: std.fs.Dir,
 
@@ -257,7 +259,7 @@ fn serve(s: *Server, listen_port: u16) !void {
     const server_port = tcp_server.listen_address.in.getPort();
     std.debug.print("\x1b[2K\rListening at http://127.0.0.1:{d}/\n", .{server_port});
 
-    var buffer: [1024]u8 = undefined;
+    var buffer: [Server.MAX_CONN_HEADER_SIZE]u8 = undefined;
     accept: while (true) {
         const conn = try tcp_server.accept();
 


### PR DESCRIPTION
This is against `v0.9.0`, not sure if GitHub realizes that.

My Chrome sent the following request headers, amounting to 1032 bytes, and causing the devserver to hang:

```
GET /projects/blobz/ HTTP/1.1
Accept: text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.7
Accept-Encoding: gzip, deflate, br, zstd
Accept-Language: de-DE,de;q=0.9,en-US;q=0.8,en;q=0.7
Cache-Control: no-cache
Connection: keep-alive
Cookie: messages=XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX; csrftoken=YYYYYYYYYYYYYYYYYYYYYYYYYYYYYYYY; sessionid=ZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZZ; loggedIn=true; SessionId=
Host: localhost:1990
Pragma: no-cache
Referer: http://localhost:1990/projects/
Sec-Fetch-Dest: document
Sec-Fetch-Mode: navigate
Sec-Fetch-Site: same-origin
Sec-Fetch-User: ?1
Upgrade-Insecure-Requests: 1
User-Agent: Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/134.0.0.0 Safari/537.36
sec-ch-ua: "Chromium";v="134", "Not:A-Brand";v="24", "Google Chrome";v="134"
sec-ch-ua-mobile: ?0
```

The fix introduces the constant `Server.MAX_CONNECTION_HEADER_SIZE : usize = 8 * 1024;` right at the beginning of the Server struct, so it's easier to spot than just a magic number.

I didn't want to introduce per-connection allocation of the header buffer, so that constant is what I went with.

Hope it helps.