### PR TITLE
Remove Tabs

### DIFF
--- a/src/cli/init/layouts/blog.xml
+++ b/src/cli/init/layouts/blog.xml
@@ -1,19 +1,19 @@
 <rss version="2.0">
-	<channel>
-		<title :text="$site.title"></title>
-		<link :text="$site.host_url"></link>
-		<description :text="$site.title.suffix(' - Blog')"></description>
-		<generator>Zine -- https://zine-ssg.io</generator>
-		<language>en-US</language>
-		<lastBuildDate :text="$build.generated.formatHTTP()"></lastBuildDate>
-		<ctx :loop="$page.subpages()">
-			<item>
-				<title :text="$loop.it.title"></title>
-	      <description :text="$loop.it.content()"></description>
-				<link :text="$site.host_url.addPath($loop.it.link())"></link>
-				<pubDate :text="$loop.it.date.formatHTTP()"></pubDate>
-				<guid :text="$site.host_url.addPath($loop.it.link())"></guid>
-			</item>
-		</ctx>
-	</channel>
+  <channel>
+    <title :text="$site.title"></title>
+    <link :text="$site.host_url"></link>
+    <description :text="$site.title.suffix(' - Blog')"></description>
+    <generator>Zine -- https://zine-ssg.io</generator>
+    <language>en-US</language>
+    <lastBuildDate :text="$build.generated.formatHTTP()"></lastBuildDate>
+    <ctx :loop="$page.subpages()">
+      <item>
+        <title :text="$loop.it.title"></title>
+        <description :text="$loop.it.content()"></description>
+        <link :text="$site.host_url.addPath($loop.it.link())"></link>
+        <pubDate :text="$loop.it.date.formatHTTP()"></pubDate>
+        <guid :text="$site.host_url.addPath($loop.it.link())"></guid>
+      </item>
+    </ctx>
+  </channel>
 </rss>

--- a/src/cli/init/layouts/devlog.xml
+++ b/src/cli/init/layouts/devlog.xml
@@ -1,21 +1,21 @@
 <rss version="2.0">
- <channel>
-	<title :text="$site.title"></title>
-	<link :text="$site.host_url"></link>
-		<description :text="$site.title.suffix(' - Devlog')"></description>
-  <generator>Zine -- https://zine-ssg.io</generator>
-  <language>en-US</language>
-  <lastBuildDate :text="$build.generated.formatHTTP()"></lastBuildDate>
-  <ctx :if="$page.subpages().first?()">
-    <ctx :loop="$if.contentSections().slice(1)">
-     <item>
-      <title :text="$loop.it.heading()"></title>
-      <description :text="$loop.it.html()"></description>
-      <link :text="$site.host_url.addPath($page.link().suffix('#', $loop.it.id))"></link>
-      <pubDate :text="$loop.it.id.parseDate().formatHTTP()"></pubDate>
-      <guid :text="$site.host_url.addPath($page.link().suffix('#', $loop.it.id))"></guid>
-     </item>
+  <channel>
+    <title :text="$site.title"></title>
+    <link :text="$site.host_url"></link>
+    <description :text="$site.title.suffix(' - Devlog')"></description>
+    <generator>Zine -- https://zine-ssg.io</generator>
+    <language>en-US</language>
+    <lastBuildDate :text="$build.generated.formatHTTP()"></lastBuildDate>
+    <ctx :if="$page.subpages().first?()">
+      <ctx :loop="$if.contentSections().slice(1)">
+        <item>
+          <title :text="$loop.it.heading()"></title>
+          <description :text="$loop.it.html()"></description>
+          <link :text="$site.host_url.addPath($page.link().suffix('#', $loop.it.id))"></link>
+          <pubDate :text="$loop.it.id.parseDate().formatHTTP()"></pubDate>
+          <guid :text="$site.host_url.addPath($page.link().suffix('#', $loop.it.id))"></guid>
+        </item>
+      </ctx>
     </ctx>
-  </ctx>
- </channel>
+  </channel>
 </rss>

--- a/src/cli/init/layouts/templates/base.shtml
+++ b/src/cli/init/layouts/templates/base.shtml
@@ -17,12 +17,12 @@
     <h1 class="site-title" :text="$site.title"></h1>
     <nav>
       <a href="$site.page('').link()">Home</a>
-      	&nbsp; • &nbsp;
+       &nbsp; • &nbsp;
       <a href="$site.page('about').link()">About</a>
-      	&nbsp; • &nbsp;
+       &nbsp; • &nbsp;
       <a href="$site.page('blog').link()">Blog</a>
       <ctx :if="$site.page('devlog').subpages().first?()">
-        	&nbsp; • &nbsp;
+         &nbsp; • &nbsp;
         <a href="$if.link()">Devlog</a>
       </ctx>
     </nav>

--- a/tests/content-scanning/collisions/content/index.smd
+++ b/tests/content-scanning/collisions/content/index.smd
@@ -5,15 +5,15 @@
 .layout = "index.shtml",
 .aliases = [
     "index.html",
-	"foo/bar/baz.html",
-	"foo/bar.html",
-	"README.html",
-	"another_index.html",
+    "foo/bar/baz.html",
+    "foo/bar.html",
+    "README.html",
+    "another_index.html",
 ],
 .alternatives = [{
-	.name = "readme",
-	.output = "nested/path/page/README.html",
-	.layout = "",
+    .name = "readme",
+    .output = "nested/path/page/README.html",
+    .layout = "",
 }],
 .draft = false,
 --- 

--- a/tests/content-scanning/collisions/content/nested/path/page.smd
+++ b/tests/content-scanning/collisions/content/nested/path/page.smd
@@ -4,15 +4,15 @@
 .author = "Sample Author",
 .layout = "page.shtml",
 .aliases = [
-	"/another_index.html",
-	// None of these aliases should collide because they're all relative:
-	"foo/bar/baz.html",
-	"foo/bar.html",
+    "/another_index.html",
+    // None of these aliases should collide because they're all relative:
+    "foo/bar/baz.html",
+    "foo/bar.html",
 ],
 .alternatives = [{
-	.name = "readme",
-	.output = "README.html",
-	.layout = "",
+    .name = "readme",
+    .output = "README.html",
+    .layout = "",
 }],
 .draft = false,
 --- 

--- a/tests/content-scanning/collisions/content/page.smd
+++ b/tests/content-scanning/collisions/content/page.smd
@@ -4,11 +4,11 @@
 .author = "Sample Author",
 .layout = "page.shtml",
 .aliases = [
-	"/foo/bar/baz.html",
-	"/foo/bar.html",
-	"/README.html",
-	"/another_page.html",
-	"/nested/path/page/index.html"
+    "/foo/bar/baz.html",
+    "/foo/bar.html",
+    "/README.html",
+    "/another_page.html",
+    "/nested/path/page/index.html"
 ],
 .alternatives = [{
   .name = "readme",

--- a/tests/content-scanning/frontmatter/content/index.smd
+++ b/tests/content-scanning/frontmatter/content/index.smd
@@ -8,17 +8,17 @@
    "/also/good.html",
 ],
 .alternatives = [{
-	.name = "good",
-	.output = "also/good/but/not/a/collision.html",
-	.layout = "foo.html",
+    .name = "good",
+    .output = "also/good/but/not/a/collision.html",
+    .layout = "foo.html",
 },{
-	.name = "also good",
-	.output = "good/url/though.html",
-	.layout = "foo.html",
+    .name = "also good",
+    .output = "good/url/though.html",
+    .layout = "foo.html",
 },{
-	.name = "good name and good url",
-	.layout = "foo.html",
-	.output = "foobar.html",
+    .name = "good name and good url",
+    .layout = "foo.html",
+    .output = "foobar.html",
 }],
 .draft = false,
 --- 

--- a/tests/content-scanning/frontmatter/content/validation-errors.smd
+++ b/tests/content-scanning/frontmatter/content/validation-errors.smd
@@ -9,17 +9,17 @@
    "bad path 💩",
 ],
 .alternatives = [{
-	.name = "good",
-	.output = "also/good/but/not/a/collision.html",
-	.layout = "foo.html",
+    .name = "good",
+    .output = "also/good/but/not/a/collision.html",
+    .layout = "foo.html",
 },{
-	.name = "",
-	.output = "good/url/though.html",
-	.layout = "foo.html",
+    .name = "",
+    .output = "good/url/though.html",
+    .layout = "foo.html",
 },{
-	.name = "good name but bad url",
-	.output = "",
-	.layout = "foo.html",
+    .name = "good name but bad url",
+    .output = "",
+    .layout = "foo.html",
 }],
 .draft = false,
 --- 

--- a/tests/content-scanning/frontmatter/content/wrong-syntax.smd
+++ b/tests/content-scanning/frontmatter/content/wrong-syntax.smd
@@ -9,17 +9,17 @@
    "bad path 💩",
 ],
 .alternatives = [{
-	.name = "good",
-	.output = "also/good/but/not/a/collision.html",
-	.layout = "foo.html",
+    .name = "good",
+    .output = "also/good/but/not/a/collision.html",
+    .layout = "foo.html",
 },{
-	.name = "",
-	.output = "good/url/though.html"
-	.layout = "foo.html",
+    .name = "",
+    .output = "good/url/though.html"
+    .layout = "foo.html",
 },{
-	.name = "good name but bad url",
-	.output = "",
-	.layout = "foo.html",
+    .name = "good name but bad url",
+    .output = "",
+    .layout = "foo.html",
 }],
 .draft = false,
 --- 

--- a/tests/content-scanning/page-analysis/content/index.smd
+++ b/tests/content-scanning/page-analysis/content/index.smd
@@ -4,9 +4,9 @@
 .author = "Sample Author",
 .layout = "index.shtml",
 .alternatives = [{
-	.name = "correct-alt",
-	.output = "arst.html",
-	.layout = "index.shtml",
+    .name = "correct-alt",
+    .output = "arst.html",
+    .layout = "index.shtml",
 }],
 .draft = false,
 --- 


### PR DESCRIPTION
This PR replaces all tabs `\t` with spaces. 4 spaces was chosen for uses in `alternatives` and within `aliases`, and 2 spaces was chosen for `.xml` and `.shtml` since those all seemed to be the most common. I found a several sites where aliases uses 3 spaces.

This PR is more of a band-aid until a SuperMD formatter to normalize indentation in the front-matter is made, along with updates to the SuperHTML formatter to more consistently remove tabs. I leave that work up to someone else because I don't understand how the AST code works.