### PR TITLE
Fix documentation links in cli/init

### DIFF
--- a/src/cli/init/content/about.smd
+++ b/src/cli/init/content/about.smd
@@ -13,10 +13,10 @@ other contributors listed on the [official repository](https://github.com/kristo
 Zine is inspired by [Hugo](https://gohugo.io) but features an entirely custom set
 of authoring languages:
 
-- [Scripty](https://zine-ssg.io/documentation/scripty/) is the small expression
+- [Scripty](https://zine-ssg.io/docs/scripty/) is the small expression
   language that both SuperHTML and SuperMD share to express templating logic.
 
-- [SuperHTML](https://zine-ssg.io/documentation/superhtml/) is the HTML templating
+- [SuperHTML](https://zine-ssg.io/docs/superhtml/) is the HTML templating
    language used by Zine. Unlike most `{{curly braced}}` templating languages,
    SuperHTML uses valid HTML syntax to express the templating logic, adding only
    minor extensions to normal HTML.  
@@ -26,7 +26,7 @@ of authoring languages:
   ># [NOTE]($block)
   >The correct file extension for SuperHTML templates is `.shtml`.
 
-- [SuperMD](https://zine-ssg.io/documentation/supermd/) is a superset of Markdown
+- [SuperMD](https://zine-ssg.io/docs/supermd/) is a superset of Markdown
   that, instead of relying on inline HTML, offers new constructs for expressing
   content embeds without pulling into your content needless layouting concerns.
   A CLI tool and language server for SuperMD is in the works.

--- a/src/cli/init/content/index.smd
+++ b/src/cli/init/content/index.smd
@@ -48,7 +48,7 @@ Some examples of devlogs in the wild:
 
 ## Next steps
 
-Make sure to read the [official Zine docs](https://zine-ssg.io/documentation/)
+Make sure to read the [official Zine docs](https://zine-ssg.io/docs/)
 and then start editing this website!
 
 Start by putting the correct information in `zine.ziggy` and then start editing


### PR DESCRIPTION
While perusing the example project I noticed some of the documentation links 404, this should remedy that.
