### PR TITLE
add nix flake

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@ public
 zig-cache
 zig-out
 scratch
+result

--- a/flake.lock
+++ b/flake.lock
@@ -1,0 +1,82 @@
+{
+  "nodes": {
+    "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
+      "locked": {
+        "lastModified": 1731533236,
+        "narHash": "sha256-l0KFg5HjrsfsO/JpG+r7fRrqm12kzFHyUHqHCVpMMbI=",
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "rev": "11707dc2f618dd54ca8739b309ec4fc024de578b",
+        "type": "github"
+      },
+      "original": {
+        "owner": "numtide",
+        "repo": "flake-utils",
+        "type": "github"
+      }
+    },
+    "nixpkgs": {
+      "locked": {
+        "lastModified": 1744932701,
+        "narHash": "sha256-fusHbZCyv126cyArUwwKrLdCkgVAIaa/fQJYFlCEqiU=",
+        "owner": "NixOS",
+        "repo": "nixpkgs",
+        "rev": "b024ced1aac25639f8ca8fdfc2f8c4fbd66c48ef",
+        "type": "github"
+      },
+      "original": {
+        "owner": "NixOS",
+        "ref": "nixos-unstable",
+        "repo": "nixpkgs",
+        "type": "github"
+      }
+    },
+    "root": {
+      "inputs": {
+        "nixpkgs": "nixpkgs",
+        "zig2nix": "zig2nix"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
+      }
+    },
+    "zig2nix": {
+      "inputs": {
+        "flake-utils": "flake-utils",
+        "nixpkgs": [
+          "nixpkgs"
+        ]
+      },
+      "locked": {
+        "lastModified": 1745026949,
+        "narHash": "sha256-P+6DKKaZniG5xJIzKpZ7Kt5qdn3RCuFDDo2Atr0y5NU=",
+        "owner": "Cloudef",
+        "repo": "zig2nix",
+        "rev": "d8730240de15020f8022b23d7d6d2fbb53cdae6d",
+        "type": "github"
+      },
+      "original": {
+        "owner": "Cloudef",
+        "repo": "zig2nix",
+        "type": "github"
+      }
+    }
+  },
+  "root": "root",
+  "version": 7
+}

--- a/flake.nix
+++ b/flake.nix
@@ -1,0 +1,42 @@
+{
+  inputs = {
+    nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
+    zig2nix = {
+      url = "github:Cloudef/zig2nix";
+      inputs.nixpkgs.follows = "nixpkgs";
+    };
+  };
+  outputs =
+    {
+      self,
+      nixpkgs,
+      zig2nix,
+      ...
+    }:
+    let
+      inherit (nixpkgs) lib;
+      forAllSystems =
+        body: lib.genAttrs lib.systems.flakeExposed (system: body nixpkgs.legacyPackages.${system});
+    in
+    {
+      packages = forAllSystems (
+        pkgs:
+        let
+          env = zig2nix.outputs.zig-env.${pkgs.system} {
+            nixpkgs = nixpkgs;
+            zig = pkgs.zig;
+          };
+        in
+        {
+          zine = env.package {
+            src = lib.cleanSource ./.;
+            nativeBuildInputs = [ ];
+            buildInputs = [ ];
+            zigPreferMusl = false;
+          };
+          default = self.packages.${pkgs.system}.zine;
+        }
+      );
+      formatter = forAllSystems (pkgs: pkgs.nixfmt-rfc-style);
+    };
+}


### PR DESCRIPTION
This should make zine easy to use on Nix/NixOS. `nix build`, `nix shell`, `nix develop` etc. should all work, and this git repo could be used to directly install the `zine` package to one's nix profile.