### PR TITLE
Fix lazyDependency on mac

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -588,14 +588,15 @@ fn setupReleaseStep(
         zine_exe_release.root_module.addImport("wuffs", wuffs.module("wuffs"));
 
         if (target.result.os.tag == .macos) {
-            const frameworks = b.lazyDependency("frameworks", .{
+            if (b.lazyDependency("frameworks", .{
                 .target = target,
                 .optimize = optimize,
-            }) orelse return;
-            zine_exe_release.addIncludePath(frameworks.path("include"));
-            zine_exe_release.addFrameworkPath(frameworks.path("Frameworks"));
-            zine_exe_release.addLibraryPath(frameworks.path("lib"));
-            zine_exe_release.linkFramework("CoreServices");
+            })) |frameworks| {
+                zine_exe_release.addIncludePath(frameworks.path("include"));
+                zine_exe_release.addFrameworkPath(frameworks.path("Frameworks"));
+                zine_exe_release.addLibraryPath(frameworks.path("lib"));
+                zine_exe_release.linkFramework("CoreServices");
+            }
         }
 
         switch (t.os_tag.?) {


### PR DESCRIPTION
It would return because the lazyDependency wasn't installed yet, then error trying to get .artifact("zine"), and then it wouldn't install the lazyDependency and try again because it errored