### PR TITLE
Fixed error when loading assets with 'serve'

### DIFF
--- a/src/cli/serve.zig
+++ b/src/cli/serve.zig
@@ -802,7 +802,7 @@ pub const Server = struct {
                 req,
                 server.build.base_dir,
                 mime_type,
-                output_path,
+                ba.input_path,
             ) catch |err| fatal.file(path, err);
         }
 


### PR DESCRIPTION
In zine/cli/serve.zig:
When looping through assets to load, output_path and input_path for the asset from the commandline args. When running from the build.zig with the setup above, this should be something like: 

zine --build-asset=example.wasm /home/user/www.example.com/.zig-cache/o/<hash>/example.wasm --output-always=/static/example.wasm

Therefore output_path = /static/example.wasm and input_path = ../zig-cache/../example.wasm

When you try to access 'example.wasm', the server crashes with:

`Error accessing file '/static/example.wasm': FileNotFound`

Looking further in zine/cli/serve.zig:
        for (server.build.build_assets.entries.items(.value)) |ba| {
            const output_path = ba.output_path orelse continue;
            if (!std.mem.eql(u8, path, output_path)) continue;
            return sendFile(
                arena,
                req,
                server.build.base_dir,
                mime_type,
                output_path, // This should be the input path. 
            ) catch |err| fatal.file(path, err);
        }


This is where I believe the bug should be. It is trying to find /static/example.wasm in the server.build.base_dir aka the website root directory. Since we ran with serve instead of build, this will break. I think instead it should be calling sendFile on the input_path instead of the output_path no?

Making this small change fixed my issue locally and allowed loading my wasm correctly in the serve mode. I'll leave it up to ppl more knowledgeable than me to determine if this was the appropriate fix....