### PR TITLE
Fix linking of resulting zine binary

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -31,7 +31,7 @@
       }: {
         zine = env.package {
           src = lib.cleanSource ./.;
-          nativeBuildInputs = [];
+          nativeBuildInputs = [ nixpkgs.legacyPackages.${system}.autoPatchelfHook ];
           buildInputs = [];
           zigPreferMusl = false;
         };


### PR DESCRIPTION
To make this binary not ask for dynamic libraries the autoPatchelfHook redirects the linked libraries to the proper nix path