### PR TITLE
fix(toc): more clean toc rendering

### DIFF
--- a/src/context/Page.zig
+++ b/src/context/Page.zig
@@ -1780,7 +1780,7 @@ pub const Builtins = struct {
             const w = &aw.writer;
 
             const ast = p._parse.ast;
-            render.htmlToc(ast, w) catch return error.OutOfMemory;
+            render.htmlToc(gpa, ast, w) catch return error.OutOfMemory;
 
             return String.init(aw.written());
         }

--- a/src/render/html.zig
+++ b/src/render/html.zig
@@ -757,13 +757,28 @@ fn renderLink(
     }
 }
 
-pub fn htmlToc(ast: Ast, w: *Writer) !void {
+pub fn htmlToc(gpa: std.mem.Allocator, ast: Ast, w: *Writer) !void {
+    var headings: std.ArrayListUnmanaged(supermd.Node) = .empty;
+    defer headings.deinit(gpa);
+
+    var min_level: i32 = 6;
+    {
+        var it = ast.md.root.firstChild();
+        while (it) |n| : (it = n.nextSibling()) {
+            if (n.nodeType() == .HEADING) {
+                try headings.append(gpa, n);
+                const l = n.headingLevel();
+                if (l < min_level) min_level = l;
+            }
+        }
+    }
+
+    if (headings.items.len == 0) return;
+
     try w.print("<ul>\n", .{});
-    var lvl: i32 = 1;
+    var lvl: i32 = min_level;
     var first_item = true;
-    var node: ?supermd.Node = ast.md.root.firstChild();
-    while (node) |n| : (node = n.nextSibling()) {
-        if (n.nodeType() != .HEADING) continue;
+    for (headings.items) |n| {
         defer first_item = false;
 
         const new_lvl = n.headingLevel();
@@ -794,7 +809,7 @@ pub fn htmlToc(ast: Ast, w: *Writer) !void {
         }
     }
 
-    while (lvl > 1) : (lvl -= 1) {
+    while (lvl > min_level) : (lvl -= 1) {
         try w.print("</li></ul>", .{});
     }
 
@@ -859,17 +874,34 @@ fn tocRenderHeading(heading: supermd.Node, w: *Writer, link: bool) !void {
     }
 }
 
-pub fn htmlTocDetails(ast: Ast, w: *Writer) !void {
-    var lvl: i32 = 1;
+pub fn htmlTocDetails(gpa: std.mem.Allocator, ast: Ast, w: *Writer) !void {
+    var headings: std.ArrayListUnmanaged(supermd.Node) = .empty;
+    defer headings.deinit(gpa);
+
+    // detect the top heading level
+    var min_level: i32 = 6;
+    {
+        var it = ast.md.root.firstChild();
+        while (it) |n| : (it = n.nextSibling()) {
+            if (n.nodeType() == .HEADING) {
+                try headings.append(gpa, n);
+                const l = n.headingLevel();
+                if (l < min_level) min_level = l;
+            }
+        }
+    }
+
+    // No headings found, output nothing
+    if (headings.items.len == 0) return;
+
+    var lvl: i32 = min_level;
     var first_item = true;
-    var node: ?supermd.Node = ast.md.root.firstChild();
-    while (node) |n| : (node = n.nextSibling()) {
-        if (n.nodeType() != .HEADING) continue;
+    for (headings.items) |n| {
         defer first_item = false;
 
         const new_lvl = n.headingLevel();
         if (new_lvl > lvl) {
-            // if (lvl == 1) {
+            // if (lvl == min_level) {
             //     try w.print("<details>\n", .{});
             //     lvl += 1;
             // }
@@ -877,15 +909,15 @@ pub fn htmlTocDetails(ast: Ast, w: *Writer) !void {
                 try w.print("<ul><li>\n", .{});
             }
 
-            // if (lvl == 1) try w.print("<summary>\n", .{});
+            // if (lvl == min_level) try w.print("<summary>\n", .{});
             try tocRenderHeading(n, w, true);
-            // if (lvl == 1) try w.print("</summary>\n", .{});
+            // if (lvl == min_level) try w.print("</summary>\n", .{});
         } else if (new_lvl < lvl) {
             try w.print("</li>", .{});
             while (new_lvl < lvl) : (lvl -= 1) {
                 try w.print("</ul></li>", .{});
             }
-            if (lvl == 1) {
+            if (lvl == min_level) {
                 try w.print("</details><details><summary>", .{});
                 try tocRenderHeading(n, w, false);
                 try w.print("</summary>", .{});
@@ -895,7 +927,7 @@ pub fn htmlTocDetails(ast: Ast, w: *Writer) !void {
             }
         } else {
             if (first_item) {
-                if (lvl == 1) {
+                if (lvl == min_level) {
                     try w.print("<details><summary>", .{});
                     try tocRenderHeading(n, w, false);
                     try w.print("</summary>", .{});
@@ -904,7 +936,7 @@ pub fn htmlTocDetails(ast: Ast, w: *Writer) !void {
                     try tocRenderHeading(n, w, true);
                 }
             } else {
-                if (lvl == 1) {
+                if (lvl == min_level) {
                     try w.print("</details><details><summary>", .{});
                     try tocRenderHeading(n, w, false);
                     try w.print("</summary>", .{});
@@ -916,7 +948,7 @@ pub fn htmlTocDetails(ast: Ast, w: *Writer) !void {
         }
     }
 
-    while (lvl > 1) : (lvl -= 1) {
+    while (lvl > min_level) : (lvl -= 1) {
         try w.print("</li></ul>", .{});
     }
 }

--- a/tests/rendering/simple/content/toc.smd
+++ b/tests/rendering/simple/content/toc.smd
@@ -1,0 +1,11 @@
+---
+.title = "Homepage",
+.date = @date("2020-07-06T00:00:00"),
+.author = "Sample Author",
+.layout = "sections.shtml",
+.draft = false,
+--- 
+
+## One
+
+## Two

--- a/tests/rendering/simple/snapshot/toc/index.html
+++ b/tests/rendering/simple/snapshot/toc/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8">
+    <title>Simple Test Website</title>
+  </head>
+  <body>
+    <h1>Homepage</h1>
+    <div>
+      <h2>-- TABLE OF CONTENTS --</h2>
+      <ul>
+<li>One</li><li>Two</ul>
+    </div>
+    <div></div>
+  </body>
+</html>


### PR DESCRIPTION
This PR improves Table of Contents (TOC) generation to correctly handle documents that start with H2 (or lower) headers, and optimizes the parsing logic.

Close: https://github.com/kristoff-it/zine/issues/186

## Changes

### `src/render/html.zig`
- Auto-detect Root Level: The TOC generator now scans for the minimum heading level (`min_level`) in the document and uses that as the root.
- No Output for Empty TOC: Returns early if no headings are found, preventing empty `<ul></ul>` tags.

### Tests
- Added `tests/rendering/toc_bug/` reproduction case.
  - Input: `index.smd` with only H2 headers.
  - Output: `snapshot/toc/index.html` confirms a flat `<ul>` list without nested empty items.

## Breaking

Before, detecting whether a toc is empty we use `$page.toc().len().gt(10)`, but now we use `$page.toc().len().gt(0)`.