### PR TITLE
feat: add minus method to scripty Int type

### DIFF
--- a/src/context/Int.zig
+++ b/src/context/Int.zig
@@ -96,7 +96,35 @@ pub const Builtins = struct {
 
             switch (args[0]) {
                 .int => |add| return Int.init(int.value +| add.value),
-                .float => @panic("TODO: int with float argument"),
+                .float => @panic("TODO: int plus with float argument"),
+                else => return argument_error,
+            }
+        }
+    };
+    pub const minus = struct {
+        pub const signature: Signature = .{
+            .params = &.{.Int},
+            .ret = .Int,
+        };
+        pub const docs_description =
+            \\Subtracts the rhs from the lhs.
+            \\
+        ;
+        pub const examples =
+            \\$page.wordCount().minus(12)
+        ;
+        pub fn call(
+            int: Int,
+            _: Allocator,
+            _: *const context.Template,
+            args: []const Value,
+        ) context.CallError!Value {
+            const argument_error: Value = .{ .err = "expected 1 int argument" };
+            if (args.len != 1) return argument_error;
+
+            switch (args[0]) {
+                .int => |subtrahend| return Int.init(int.value -| subtrahend.value),
+                .float => @panic("TODO: int minus with float argument"),
                 else => return argument_error,
             }
         }


### PR DESCRIPTION
This commit adds a new method to Int, allowing for subtraction of values.

## How I Tested

I ran `zig build test` and observed there were no errors. I couldn't find any existing tests for Scripty contexts, so I did not create any new tests. This gives me confidence this change does not break anything, but it does not give me confidence that the change does what it intends.

For that, I built Zine from my branch in debug mode (Zig 0.15.2) and made some edits to my personal site, adding the following snippet to my base page layout:

```
  <div id="attribution" class="centered">
    Wordcount:
    <ctx :text=$page.wordCount()></ctx>
    Wordcount minus 3:
    <ctx :text=$page.wordCount().minus(3)></ctx>
    Written by
    <ctx :text=$page.author></ctx>
    on
    <ctx :text="$page.date.format('January 02, 2006')"></ctx><ctx :if="$page.custom.get?('edited')">, last edited
      <ctx :text="$if.format('January 02, 2006')"></ctx></ctx>.
  </div>
```

Notice the use of `.minus(3)`. I used the newly-built Zine executable to run a development server for my site, and confirmed that there were no crashes, and that the contexts render appropriately:

<img width="1213" height="341" alt="image" src="https://github.com/user-attachments/assets/2afd16b1-9965-4184-b8b2-d8fe5e142a78" />
