### PR TITLE
Feat: export to single html file

### DIFF
--- a/src/Build.zig
+++ b/src/Build.zig
@@ -26,6 +26,7 @@ cfg: *const root.Config,
 build_assets: *const std.StringArrayHashMapUnmanaged(BuildAsset),
 any_prerendering_error: bool = false,
 any_rendering_error: std.atomic.Value(bool) = .{ .raw = false },
+is_export_mode: bool = false,
 
 base_dir_path: []const u8,
 base_dir: std.fs.Dir,
@@ -183,6 +184,7 @@ pub fn load(gpa: Allocator, cfg: *const root.Config, opts: root.Options) Build {
         .pt = path_table,
         .mode = mode,
         .i18n_dir = i18n_dir,
+        .is_export_mode = opts.is_export_mode,
     };
 }
 

--- a/src/cli/export.zig
+++ b/src/cli/export.zig
@@ -1,0 +1,183 @@
+const std = @import("std");
+const root = @import("../root.zig");
+const render = @import("../render.zig");
+const fatal = @import("../fatal.zig");
+const context = @import("../context.zig");
+const BuildAsset = root.BuildAsset;
+const Variant = @import("../Variant.zig");
+const embed = @import("../render/embed.zig");
+const embedCss = embed.embedCss;
+const Command = @import("release.zig").Command;
+const log = std.log.scoped(.export_cmd);
+
+pub fn exportContent(gpa: std.mem.Allocator, args: []const []const u8) bool {
+    exportContentFn(gpa, args) catch |err| {
+        fatal.msg("Error during export: {s}", .{@errorName(err)});
+        return true;
+    };
+    return false;
+}
+
+fn exportContentFn(gpa: std.mem.Allocator, args: []const []const u8) !void {
+    var cmd = try Command.parse(gpa, args, help_message);
+    defer cmd.deinit(gpa);
+
+    // 1. Load the Project Configuration
+    const cfg, const base_dir_path = root.Config.load(gpa);
+
+    const worker = @import("../worker.zig");
+    worker.start();
+    defer worker.stopWaitAndDeinit();
+
+    // 2. Initialize Build in 'Memory' mode
+    var build = try root.run(gpa, &cfg, .{
+        .base_dir_path = base_dir_path,
+        .build_assets = &cmd.build_assets, // TODO: this feature needs more tests and modifications
+        .drafts = cmd.drafts,
+        .mode = .memory,
+        .is_export_mode = true,
+    });
+    defer build.deinit(gpa);
+
+    const export_opts = switch (cfg) {
+        .Site => |s| s.@"export",
+        .Multilingual => |m| m.@"export",
+    };
+
+    // Prepare output base dir
+    const output_dir = cmd.output_dir_path orelse export_opts.output_dir;
+    try std.fs.cwd().makePath(output_dir);
+
+    // 3. Iterate over variants and generate an output file for each
+    for (build.variants) |*variant| {
+        const variant_dir_path = if (variant.output_path_prefix.len == 0)
+            output_dir
+        else
+            try std.fs.path.join(gpa, &.{ output_dir, variant.output_path_prefix });
+        defer if (variant.output_path_prefix.len > 0) gpa.free(variant_dir_path);
+
+        if (variant.output_path_prefix.len > 0) {
+            try std.fs.cwd().makePath(variant_dir_path);
+        }
+
+        const output_path = try std.fs.path.join(gpa, &.{ variant_dir_path, export_opts.output_name });
+        defer gpa.free(output_path);
+
+        const file = std.fs.cwd().createFile(output_path, .{ .truncate = true, .exclusive = !cmd.force }) catch |err| switch (err) {
+            error.PathAlreadyExists => {
+                fatal.msg("Error: output file '{s}' already exists. Use --force to overwrite.", .{output_path});
+                return;
+            },
+            else => return err,
+        };
+        defer file.close();
+
+        var output_buf: [4096]u8 = undefined;
+        var writer_state = file.writer(&output_buf);
+        const writer = &writer_state.interface;
+
+        for (export_opts.custom_styles) |style_path| {
+            _ = embedCss(gpa, build.base_dir, style_path, writer) catch |err| blk: {
+                log.err("Failed to embed custom style '{s}': {s}", .{
+                    style_path,
+                    @errorName(err),
+                });
+                break :blk false;
+            };
+        }
+
+        // Find the root page for this variant
+        if (variant.root_index) |root_page_id| {
+            try renderRecursive(gpa, variant, root_page_id, 1, writer, &build);
+        }
+
+        try file.sync();
+        var buf: [256]u8 = undefined;
+        var stdout_writer = std.fs.File.stdout().writer(&buf);
+        const stdout = &stdout_writer.interface;
+        try stdout.print("Exported to {s}\n", .{output_path});
+        try stdout.flush();
+    }
+}
+
+// Recursive helper function to render pages in hierarchical order
+fn renderRecursive(
+    gpa: std.mem.Allocator,
+    variant: *const Variant,
+    page_id: u32,
+    current_depth: u32,
+    writer: anytype,
+    build: *root.Build,
+) !void {
+    const page = &variant.pages.items[page_id];
+
+    // Skip if page parsing failed or is inactive
+    if (!page._parse.active) return;
+
+    // Render Frontmatter as HTML (Title, optional Author/Date)
+    try writer.print(
+        "<div class=\"zine-page zine-depth-{d}\" id=\"{f}\">\n",
+        .{
+            current_depth,
+            PageIdFormatter{ .page = page, .variant = variant },
+        },
+    );
+
+    embed.processExportHtml(gpa, build, page, page._render.out, writer) catch |err| {
+        log.err("Failed to process HTML for page '{f}': {s}", .{
+            PageIdFormatter{ .page = page, .variant = variant },
+            @errorName(err),
+        });
+        // Write original content as fallback
+        try writer.writeAll(page._render.out);
+    };
+
+    // Recursive call for subpages/subsections
+    if (page._scan.subsection_id != 0) { // If this page is a section (index.smd)
+        const section = &variant.sections.items[page._scan.subsection_id];
+        // Iterate through pages directly contained in this section
+        for (section.pages.items) |child_page_id| {
+            if (child_page_id == page_id) continue; // Skip self if it's the index page
+
+            // Render child page recursively with increased depth
+            try renderRecursive(gpa, variant, child_page_id, current_depth + 1, writer, build);
+        }
+    }
+
+    try writer.writeAll(
+        "</div>\n" // Close zine-page div
+    );
+}
+
+const PageIdFormatter = struct {
+    variant: *const Variant,
+    page: *const context.Page,
+
+    pub fn format(
+        self: PageIdFormatter,
+        writer: anytype,
+    ) !void {
+        const v = self.variant;
+        try writer.print("{f}", .{
+            self.page._scan.url.fmt(
+                &v.string_table,
+                &v.path_table,
+                "/", // Ensure leading slash
+                false, // No trailing slash
+            ),
+        });
+    }
+};
+
+const help_message =
+    \\Usage: zine export [OPTIONS]
+    \\
+    \\Command specific options:
+    \\  --output, -o DIR                              Directory where to output the file
+    \\  --force, -f                                   Overwrite existing output file
+    \\  --build-asset=<NAME> <PATH> [INSTALL_OPTS]    Define a build asset
+    \\  --drafts                                      Include draft content
+    \\  --help, -h                                    Show this help menu
+    \\
+    \\
+;

--- a/src/cli/export.zig
+++ b/src/cli/export.zig
@@ -1,14 +1,14 @@
 const std = @import("std");
-const root = @import("../root.zig");
-const render = @import("../render.zig");
-const fatal = @import("../fatal.zig");
+
 const context = @import("../context.zig");
-const BuildAsset = root.BuildAsset;
-const Variant = @import("../Variant.zig");
+const fatal = @import("../fatal.zig");
+const render = @import("../render.zig");
 const embed = @import("../render/embed.zig");
 const embedCss = embed.embedCss;
+const root = @import("../root.zig");
+const BuildAsset = root.BuildAsset;
+const Variant = @import("../Variant.zig");
 const Command = @import("release.zig").Command;
-const log = std.log.scoped(.export_cmd);
 
 pub fn exportContent(gpa: std.mem.Allocator, args: []const []const u8) bool {
     exportContentFn(gpa, args) catch |err| {
@@ -72,13 +72,12 @@ fn exportContentFn(gpa: std.mem.Allocator, args: []const []const u8) !void {
         };
         defer file.close();
 
-        var output_buf: [4096]u8 = undefined;
-        var writer_state = file.writer(&output_buf);
-        const writer = &writer_state.interface;
+        const FileWriterType = std.io.GenericWriter(std.fs.File, std.fs.File.WriteError, std.fs.File.write);
+        const writer = FileWriterType{ .context = file };
 
         for (export_opts.custom_styles) |style_path| {
             _ = embedCss(gpa, build.base_dir, style_path, writer) catch |err| blk: {
-                log.err("Failed to embed custom style '{s}': {s}", .{
+                std.debug.print("error: Failed to embed custom style '{s}': {s}\n", .{
                     style_path,
                     @errorName(err),
                 });
@@ -92,11 +91,7 @@ fn exportContentFn(gpa: std.mem.Allocator, args: []const []const u8) !void {
         }
 
         try file.sync();
-        var buf: [256]u8 = undefined;
-        var stdout_writer = std.fs.File.stdout().writer(&buf);
-        const stdout = &stdout_writer.interface;
-        try stdout.print("Exported to {s}\n", .{output_path});
-        try stdout.flush();
+        std.debug.print("Exported to {s}\n", .{output_path});
     }
 }
 
@@ -124,7 +119,7 @@ fn renderRecursive(
     );
 
     embed.processExportHtml(gpa, build, page, page._render.out, writer) catch |err| {
-        log.err("Failed to process HTML for page '{f}': {s}", .{
+        std.debug.print("error: Failed to process HTML for page '{f}': {s}\n", .{
             PageIdFormatter{ .page = page, .variant = variant },
             @errorName(err),
         });

--- a/src/cli/release.zig
+++ b/src/cli/release.zig
@@ -12,7 +12,7 @@ pub fn release(gpa: Allocator, args: []const []const u8) bool {
         error.OutOfMemory => fatal.oom(),
     };
 
-    const cmd: Command = try .parse(gpa, args);
+    const cmd: Command = try .parse(gpa, args, help_message);
     const cfg, const base_dir_path = root.Config.load(gpa);
 
     worker.start();
@@ -59,7 +59,7 @@ pub const Command = struct {
         ba.deinit(gpa);
     }
 
-    pub fn parse(gpa: Allocator, args: []const []const u8) !Command {
+    pub fn parse(gpa: Allocator, args: []const []const u8, help: []const u8) !Command {
         var output_dir_path: ?[]const u8 = null;
         var build_assets: std.StringArrayHashMapUnmanaged(BuildAsset) = .empty;
         var drafts = false;
@@ -71,7 +71,8 @@ pub const Command = struct {
         while (idx < args.len) : (idx += 1) {
             const arg = args[idx];
             if (eql(u8, arg, "-h") or eql(u8, arg, "--help")) {
-                fatal.msg(help_message, .{});
+                std.debug.print("{s}", .{help});
+                std.process.exit(1);
             } else if (eql(u8, arg, "-f") or eql(u8, arg, "--force")) {
                 force = true;
             } else if (eql(u8, arg, "-o") or eql(u8, arg, "--output")) {

--- a/src/context/Build.zig
+++ b/src/context/Build.zig
@@ -7,6 +7,7 @@ const context = @import("../context.zig");
 const Signature = @import("doctypes.zig").Signature;
 const Allocator = std.mem.Allocator;
 const Value = context.Value;
+const Bool = context.Bool;
 const Optional = context.Optional;
 const uninitialized = utils.uninitialized;
 
@@ -145,6 +146,33 @@ pub const Builtins = struct {
                 Optional.init(gpa, build._git)
             else
                 Optional.Null;
+        }
+    };
+
+    pub const isExportMode = struct {
+        pub const signature: Signature = .{ .ret = .Bool };
+        pub const docs_description =
+            \\Returns true if the site is being built in export mode.
+            \\
+            \\Export mode creates a single self-contained HTML file
+            \\with all CSS and images embedded.
+        ;
+        pub const examples =
+            \\<div :if="$build.isExportMode()">This only shows in export mode</div>
+            \\<div :if="$build.isExportMode().not()">This only shows in normal mode</div>
+        ;
+        pub fn call(
+            _: *const Build,
+            _: Allocator,
+            ctx: *const context.Template,
+            args: []const Value,
+        ) context.CallError!Value {
+            const bad_arg: Value = .{
+                .err = "expected 0 arguments",
+            };
+            if (args.len != 0) return bad_arg;
+
+            return Bool.init(ctx._meta.build.is_export_mode);
         }
     };
 };

--- a/src/main.zig
+++ b/src/main.zig
@@ -25,6 +25,7 @@ const Command = enum {
     @"-v",
     @"--version",
     // Because other ssgs have them:
+    @"export",
     serve,
     server,
     dev,
@@ -120,6 +121,7 @@ pub fn main() u8 {
     const any_error = switch (cmd) {
         .init => @import("cli/init.zig").init(gpa, args[2..]),
         .release => @import("cli/release.zig").release(gpa, args[2..]),
+        .@"export" => @import("cli/export.zig").exportContent(gpa, args[2..]),
         .debug => @import("cli/debug.zig").debug(gpa, args[2..]),
         .help, .@"-h", .@"--help" => fatal.help(),
         .version, .@"-v", .@"--version" => printVersion(),

--- a/src/render/embed.zig
+++ b/src/render/embed.zig
@@ -1,0 +1,372 @@
+// this implementation is not strong and robust
+
+const std = @import("std");
+const context = @import("../context.zig");
+const Build = @import("../Build.zig");
+const mime = @import("mime");
+const log = std.log.scoped(.embed);
+
+pub fn processExportHtml(
+    gpa: std.mem.Allocator,
+    build: *const Build,
+    page: *const context.Page,
+    html_content: []const u8,
+    w: anytype,
+) !void {
+    var i: usize = 0;
+    var scratch = std.ArrayListUnmanaged(u8){};
+    defer scratch.deinit(gpa);
+
+    // Get page URL for prefix
+    const v = build.variants[page._scan.variant_id];
+    var page_url_buffer: [512]u8 = undefined;
+    const page_url_formatted = page._scan.url.fmt(&v.string_table, &v.path_table, "/", false);
+    const page_url = std.fmt.bufPrint(&page_url_buffer, "{f}", .{page_url_formatted}) catch return;
+
+    while (i < html_content.len) {
+        const lt = std.mem.indexOfScalarPos(u8, html_content, i, '<');
+        if (lt == null) {
+            try w.writeAll(html_content[i..]);
+            break;
+        }
+        try w.writeAll(html_content[i..lt.?]);
+        i = lt.?;
+
+        // Handle comments <!-- ... -->
+        if (std.mem.startsWith(u8, html_content[i..], "<!--")) {
+            if (std.mem.indexOfPos(u8, html_content, i, "-->")) |end| {
+                const comment_end = end + 3;
+                try w.writeAll(html_content[i..comment_end]);
+                i = comment_end;
+                continue;
+            }
+            // If malformed (no closing -->), let the loop continue to process < as part of tag or text
+        }
+
+        // Naive tag parsing
+        var j = i + 1;
+        // Skip / if closing tag
+        if (j < html_content.len and html_content[j] == '/') {
+            j += 1;
+        }
+
+        // Get tag name
+        const name_start = j;
+        while (j < html_content.len and (std.ascii.isAlphanumeric(html_content[j]) or html_content[j] == '-')) : (j += 1) {}
+        const tag_name = html_content[name_start..j];
+
+        // Find end of tag >
+        var cursor = j;
+        var in_quote: ?u8 = null;
+        var tag_end: ?usize = null;
+
+        while (cursor < html_content.len) : (cursor += 1) {
+            const char = html_content[cursor];
+            if (in_quote) |q| {
+                if (char == q) in_quote = null;
+            } else {
+                if (char == '"' or char == '\'') {
+                    in_quote = char;
+                } else if (char == '>') {
+                    tag_end = cursor;
+                    break;
+                }
+            }
+        }
+
+        if (tag_end == null) {
+            // Malformed, just print <
+            try w.writeByte('<');
+            i += 1;
+            continue;
+        }
+
+        var tag_content = html_content[i .. tag_end.? + 1]; // <... >
+        var modified_tag_buf: std.ArrayListUnmanaged(u8) = .{};
+        defer modified_tag_buf.deinit(gpa);
+
+        // Check for ID attribute to prefix
+        if (findAttrValue(tag_content, "id")) |id| {
+            scratch.clearRetainingCapacity();
+            try scratch.appendSlice(gpa, page_url);
+            try scratch.appendSlice(gpa, "-");
+            try scratch.appendSlice(gpa, id);
+
+            try writeTagWithNewAttr(modified_tag_buf.writer(gpa), tag_content, "id", scratch.items);
+            tag_content = modified_tag_buf.items;
+        }
+
+        var handled = false;
+
+        if (std.mem.eql(u8, tag_name, "img")) {
+            handled = handleImg(gpa, build, page, tag_content, w) catch |err| blk: {
+                log.err("Failed to process img tag: {s}", .{@errorName(err)});
+                break :blk false;
+            };
+        } else if (std.mem.eql(u8, tag_name, "a")) {
+            handled = handleAnchor(gpa, tag_content, w, &scratch, page_url) catch |err| blk: {
+                log.err("Failed to process anchor tag: {s}", .{@errorName(err)});
+                break :blk false;
+            };
+        }
+
+        if (!handled) {
+            // If no special processing was done, write original tag
+            try w.writeAll(tag_content);
+        }
+
+        i = tag_end.? + 1;
+    }
+}
+
+fn handleImg(
+    gpa: std.mem.Allocator,
+    build: *const Build,
+    page: *const context.Page,
+    tag_content: []const u8,
+    w: anytype,
+) !bool {
+    const span = findAttrSpan(tag_content, "src") orelse return false;
+    const src = tag_content[span.start..span.end];
+
+    if (std.mem.startsWith(u8, src, "http://") or std.mem.startsWith(u8, src, "https://")) {
+        log.warn("Remote image embedding is not supported. Skipping embed for src: {s}", .{src});
+        return false;
+    }
+
+    if (try resolveRawPath(gpa, src, build, page)) |abs_path| {
+        defer gpa.free(abs_path);
+
+        // Write part before src value
+        try w.writeAll(tag_content[0..span.start]);
+
+        // Stream the embedded image
+        const embedded = try embedImage(gpa, abs_path, w);
+        if (!embedded) {
+            // Fallback to original src if embed fails
+            log.warn("Failed to embed image at {s}. Using original src.", .{abs_path});
+            try w.writeAll(src);
+        }
+
+        // Write part after src value
+        try w.writeAll(tag_content[span.end..]);
+        return true;
+    }
+
+    return false;
+}
+
+fn handleAnchor(
+    gpa: std.mem.Allocator,
+    tag_content: []const u8,
+    w: anytype,
+    scratch: *std.ArrayListUnmanaged(u8),
+    page_url: []const u8,
+) !bool {
+    const href = findAttrValue(tag_content, "href") orelse return false;
+
+    if (std.mem.startsWith(u8, href, "#")) {
+        // Internal anchor link, add page prefix
+        const anchor_text = href[1..]; // Remove #
+
+        scratch.clearRetainingCapacity();
+        const writer = scratch.writer(gpa);
+
+        try writer.writeByte('#');
+        try writer.writeAll(page_url);
+        try writer.writeByte('-');
+        try writer.writeAll(anchor_text);
+
+        try writeTagWithNewAttr(w, tag_content, "href", scratch.items);
+        return true;
+    } else if (std.mem.startsWith(u8, href, "/")) {
+        // Internal site link, convert path to hyphen format
+        const path_part = href[1..]; // Remove leading /
+
+        scratch.clearRetainingCapacity();
+        const writer = scratch.writer(gpa);
+
+        // Check if it contains a # for anchor
+        if (std.mem.indexOf(u8, path_part, "#")) |hash_pos| {
+            const path_before_hash_segment = href[1 .. hash_pos + 1];
+            const anchor_text = path_part[hash_pos + 1 ..];
+
+            try writer.writeAll(path_before_hash_segment);
+            try writer.writeByte('-');
+            try writer.writeAll(anchor_text);
+        } else {
+            var processed_path: []const u8 = href;
+            if (processed_path.len > 1 and processed_path[processed_path.len - 1] == '/') {
+                processed_path = processed_path[0 .. processed_path.len - 1];
+            }
+
+            try writer.writeAll("#");
+            try writer.writeAll(processed_path);
+        }
+
+        try writeTagWithNewAttr(w, tag_content, "href", scratch.items);
+        return true;
+    }
+
+    return false;
+}
+
+
+const Span = struct {
+    start: usize,
+    end: usize,
+};
+
+pub fn findAttrSpan(tag: []const u8, attr: []const u8) ?Span {
+    var i: usize = 0;
+    while (i < tag.len) {
+        const start = std.mem.indexOfPos(u8, tag, i, attr) orelse return null;
+        if (start > 0 and (std.ascii.isAlphanumeric(tag[start - 1]) or tag[start - 1] == '-')) {
+            i = start + 1;
+            continue;
+        }
+        var cursor = start + attr.len;
+        if (cursor < tag.len and tag[cursor] != ' ' and tag[cursor] != '=') {
+            i = start + 1;
+            continue;
+        }
+        while (cursor < tag.len and tag[cursor] == ' ') cursor += 1;
+        if (cursor >= tag.len or tag[cursor] != '=') return null;
+        cursor += 1;
+        while (cursor < tag.len and tag[cursor] == ' ') cursor += 1;
+        if (cursor >= tag.len) return null;
+
+        const q = tag[cursor];
+        if (q == '"' or q == '\'') {
+            cursor += 1;
+            const val_start = cursor;
+            while (cursor < tag.len and tag[cursor] != q) cursor += 1;
+            return Span{ .start = val_start, .end = cursor };
+        } else {
+            const val_start = cursor;
+            while (cursor < tag.len and tag[cursor] != ' ' and tag[cursor] != '>') cursor += 1;
+            return Span{ .start = val_start, .end = cursor };
+        }
+    }
+    return null;
+}
+
+pub fn findAttrValue(tag: []const u8, attr: []const u8) ?[]const u8 {
+    if (findAttrSpan(tag, attr)) |span| {
+        return tag[span.start..span.end];
+    }
+    return null;
+}
+
+pub fn writeTagWithNewAttr(w: anytype, tag: []const u8, attr: []const u8, new_val: []const u8) !void {
+    if (findAttrSpan(tag, attr)) |span| {
+        try w.writeAll(tag[0..span.start]);
+        try w.writeAll(new_val);
+        try w.writeAll(tag[span.end..]);
+    } else {
+        try w.writeAll(tag);
+    }
+}
+
+pub fn embedCss(
+    gpa: std.mem.Allocator,
+    dir: std.fs.Dir,
+    path: []const u8,
+    w: anytype,
+) !bool {
+    const extension = std.fs.path.extension(path);
+    if (!std.mem.eql(u8, extension, ".css")) {
+        log.warn("Unsupported css extension: {s}", .{path});
+        return false;
+    }
+
+    const file = try dir.openFile(path, .{});
+    defer file.close();
+
+    // Get file size first
+    const file_size = try file.getEndPos();
+
+    // Allocate buffer for file content
+    const content = try gpa.alloc(u8, file_size);
+    defer gpa.free(content);
+
+    // Read entire file
+    _ = try file.readAll(content);
+
+    try w.print("<style>\n{s}\n</style>", .{content});
+    return true;
+}
+
+pub fn embedImage(
+    gpa: std.mem.Allocator,
+    abs_path: []const u8, // Expecting absolute path or path relative to cwd
+    w: anytype,
+) !bool {
+    const extension = std.fs.path.extension(abs_path);
+    if (extension.len < 2) return false;
+
+    const mime_enum = mime.extension_map.get(extension) orelse return false;
+    const mime_type = @tagName(mime_enum);
+    if (!std.mem.startsWith(u8, mime_type, "image/")){
+        log.warn("Unsupported mime type of images: {s}", .{mime_type});
+        return false;
+    }
+
+    const file = try std.fs.openFileAbsolute(abs_path, .{});
+    defer file.close();
+
+    // Get file size first
+    const file_size = try file.getEndPos();
+
+    // Calculate base64 encoded size
+    const b64_len = std.base64.standard.Encoder.calcSize(file_size);
+
+    // Allocate single buffer for both file content and base64
+    const buffer = try gpa.alloc(u8, b64_len);
+    defer gpa.free(buffer);
+
+    // Store file content at the end of the buffer
+    const file_content_start = b64_len - file_size;
+    const file_content = buffer[file_content_start..];
+    _ = try file.readAll(file_content);
+
+    // Encode base64 to the beginning of the buffer
+    _ = std.base64.standard.Encoder.encode(buffer, file_content);
+
+    try w.print("data:{s};base64,{s}", .{ mime_type, buffer });
+
+    return true;
+}
+
+pub fn resolveRawPath(
+    gpa: std.mem.Allocator,
+    path: []const u8,
+    build: *const Build,
+    page: *const context.Page,
+) !?[]const u8 {
+    if (path.len == 0) return null;
+
+    const base_dir_path = build.base_dir_path;
+
+    // Check if it's a build asset first
+    if (build.build_assets.get(path)) |build_asset| {
+        return try std.fs.path.join(gpa, &.{ base_dir_path, build_asset.input_path });
+    }
+
+    if (path[0] == '/') {
+        // Site asset
+        const assets_dir_path = build.cfg.getAssetsDirPath();
+        return try std.fs.path.join(gpa, &.{ base_dir_path, assets_dir_path, path[1..] });
+    } else {
+        // Page asset (relative)
+        const v = build.variants[page._scan.variant_id];
+        const content_dir_path = v.content_dir_path;
+
+        const page_dir_path = try std.fmt.allocPrint(gpa, "{f}", .{
+            page._scan.file.path.fmt(&v.string_table, &v.path_table, null, false),
+        });
+        defer gpa.free(page_dir_path);
+
+        return try std.fs.path.join(gpa, &.{ base_dir_path, content_dir_path, page_dir_path, path });
+    }
+}

--- a/src/render/embed.zig
+++ b/src/render/embed.zig
@@ -1,10 +1,10 @@
-// this implementation is not strong and robust
-
 const std = @import("std");
-const context = @import("../context.zig");
-const Build = @import("../Build.zig");
+
 const mime = @import("mime");
-const log = std.log.scoped(.embed);
+const superhtml = @import("superhtml");
+
+const Build = @import("../Build.zig");
+const context = @import("../context.zig");
 
 pub fn processExportHtml(
     gpa: std.mem.Allocator,
@@ -13,259 +13,162 @@ pub fn processExportHtml(
     html_content: []const u8,
     w: anytype,
 ) !void {
-    var i: usize = 0;
-    var scratch = std.ArrayListUnmanaged(u8){};
-    defer scratch.deinit(gpa);
+    var ast = try superhtml.html.Ast.init(gpa, html_content, .html, false);
+    defer ast.deinit(gpa);
 
-    // Get page URL for prefix
+    // Pre-calculate page URL prefix once
     const v = build.variants[page._scan.variant_id];
-    var page_url_buffer: [512]u8 = undefined;
     const page_url_formatted = page._scan.url.fmt(&v.string_table, &v.path_table, "/", false);
-    const page_url = std.fmt.bufPrint(&page_url_buffer, "{f}", .{page_url_formatted}) catch return;
+    const page_url = try std.fmt.allocPrint(gpa, "{f}", .{page_url_formatted});
+    defer gpa.free(page_url);
 
-    while (i < html_content.len) {
-        const lt = std.mem.indexOfScalarPos(u8, html_content, i, '<');
-        if (lt == null) {
-            try w.writeAll(html_content[i..]);
-            break;
-        }
-        try w.writeAll(html_content[i..lt.?]);
-        i = lt.?;
+    // Handle empty AST
+    if (ast.nodes.len == 0) return;
 
-        // Handle comments <!-- ... -->
-        if (std.mem.startsWith(u8, html_content[i..], "<!--")) {
-            if (std.mem.indexOfPos(u8, html_content, i, "-->")) |end| {
-                const comment_end = end + 3;
-                try w.writeAll(html_content[i..comment_end]);
-                i = comment_end;
-                continue;
-            }
-            // If malformed (no closing -->), let the loop continue to process < as part of tag or text
-        }
-
-        // Naive tag parsing
-        var j = i + 1;
-        // Skip / if closing tag
-        if (j < html_content.len and html_content[j] == '/') {
-            j += 1;
-        }
-
-        // Get tag name
-        const name_start = j;
-        while (j < html_content.len and (std.ascii.isAlphanumeric(html_content[j]) or html_content[j] == '-')) : (j += 1) {}
-        const tag_name = html_content[name_start..j];
-
-        // Find end of tag >
-        var cursor = j;
-        var in_quote: ?u8 = null;
-        var tag_end: ?usize = null;
-
-        while (cursor < html_content.len) : (cursor += 1) {
-            const char = html_content[cursor];
-            if (in_quote) |q| {
-                if (char == q) in_quote = null;
-            } else {
-                if (char == '"' or char == '\'') {
-                    in_quote = char;
-                } else if (char == '>') {
-                    tag_end = cursor;
-                    break;
-                }
-            }
-        }
-
-        if (tag_end == null) {
-            // Malformed, just print <
-            try w.writeByte('<');
-            i += 1;
-            continue;
-        }
-
-        var tag_content = html_content[i .. tag_end.? + 1]; // <... >
-        var modified_tag_buf: std.ArrayListUnmanaged(u8) = .{};
-        defer modified_tag_buf.deinit(gpa);
-
-        // Check for ID attribute to prefix
-        if (findAttrValue(tag_content, "id")) |id| {
-            scratch.clearRetainingCapacity();
-            try scratch.appendSlice(gpa, page_url);
-            try scratch.appendSlice(gpa, "-");
-            try scratch.appendSlice(gpa, id);
-
-            try writeTagWithNewAttr(modified_tag_buf.writer(gpa), tag_content, "id", scratch.items);
-            tag_content = modified_tag_buf.items;
-        }
-
-        var handled = false;
-
-        if (std.mem.eql(u8, tag_name, "img")) {
-            handled = handleImg(gpa, build, page, tag_content, w) catch |err| blk: {
-                log.err("Failed to process img tag: {s}", .{@errorName(err)});
-                break :blk false;
-            };
-        } else if (std.mem.eql(u8, tag_name, "a")) {
-            handled = handleAnchor(gpa, tag_content, w, &scratch, page_url) catch |err| blk: {
-                log.err("Failed to process anchor tag: {s}", .{@errorName(err)});
-                break :blk false;
-            };
-        }
-
-        if (!handled) {
-            // If no special processing was done, write original tag
-            try w.writeAll(tag_content);
-        }
-
-        i = tag_end.? + 1;
-    }
+    // Start recursive rendering from root
+    try renderNode(gpa, &ast, 0, build, page, html_content, w, page_url);
 }
 
-fn handleImg(
+fn renderNode(
     gpa: std.mem.Allocator,
+    ast: *const superhtml.html.Ast,
+    node_idx: u32,
     build: *const Build,
     page: *const context.Page,
-    tag_content: []const u8,
+    src: []const u8,
     w: anytype,
-) !bool {
-    const span = findAttrSpan(tag_content, "src") orelse return false;
-    const src = tag_content[span.start..span.end];
-
-    if (std.mem.startsWith(u8, src, "http://") or std.mem.startsWith(u8, src, "https://")) {
-        log.warn("Remote image embedding is not supported. Skipping embed for src: {s}", .{src});
-        return false;
-    }
-
-    if (try resolveRawPath(gpa, src, build, page)) |abs_path| {
-        defer gpa.free(abs_path);
-
-        // Write part before src value
-        try w.writeAll(tag_content[0..span.start]);
-
-        // Stream the embedded image
-        const embedded = try embedImage(gpa, abs_path, w);
-        if (!embedded) {
-            // Fallback to original src if embed fails
-            log.warn("Failed to embed image at {s}. Using original src.", .{abs_path});
-            try w.writeAll(src);
-        }
-
-        // Write part after src value
-        try w.writeAll(tag_content[span.end..]);
-        return true;
-    }
-
-    return false;
-}
-
-fn handleAnchor(
-    gpa: std.mem.Allocator,
-    tag_content: []const u8,
-    w: anytype,
-    scratch: *std.ArrayListUnmanaged(u8),
     page_url: []const u8,
-) !bool {
-    const href = findAttrValue(tag_content, "href") orelse return false;
+) !void {
+    const node = ast.nodes[node_idx];
 
-    if (std.mem.startsWith(u8, href, "#")) {
-        // Internal anchor link, add page prefix
-        const anchor_text = href[1..]; // Remove #
+    switch (node.kind) {
+        .root => {
+            var child_idx = node.first_child_idx;
+            while (child_idx != 0) {
+                try renderNode(gpa, ast, child_idx, build, page, src, w, page_url);
+                child_idx = ast.nodes[child_idx].next_idx;
+            }
+        },
+        .text, .comment, .doctype => {
+            // Write content as-is
+            try w.writeAll(node.open.slice(src));
+        },
+        else => {
+            // Element handling
+            const tag_name = node.startTagIterator(src, .html).name_span.slice(src);
 
-        scratch.clearRetainingCapacity();
-        const writer = scratch.writer(gpa);
-
-        try writer.writeByte('#');
-        try writer.writeAll(page_url);
-        try writer.writeByte('-');
-        try writer.writeAll(anchor_text);
-
-        try writeTagWithNewAttr(w, tag_content, "href", scratch.items);
-        return true;
-    } else if (std.mem.startsWith(u8, href, "/")) {
-        // Internal site link, convert path to hyphen format
-        const path_part = href[1..]; // Remove leading /
-
-        scratch.clearRetainingCapacity();
-        const writer = scratch.writer(gpa);
-
-        // Check if it contains a # for anchor
-        if (std.mem.indexOf(u8, path_part, "#")) |hash_pos| {
-            const path_before_hash_segment = href[1 .. hash_pos + 1];
-            const anchor_text = path_part[hash_pos + 1 ..];
-
-            try writer.writeAll(path_before_hash_segment);
-            try writer.writeByte('-');
-            try writer.writeAll(anchor_text);
-        } else {
-            var processed_path: []const u8 = href;
-            if (processed_path.len > 1 and processed_path[processed_path.len - 1] == '/') {
-                processed_path = processed_path[0 .. processed_path.len - 1];
+            // 1. Filter: Skip unwanted tags completely (including children)
+            if (std.mem.eql(u8, tag_name, "script") or std.mem.eql(u8, tag_name, "link")) {
+                return;
             }
 
-            try writer.writeAll("#");
-            try writer.writeAll(processed_path);
-        }
+            // 2. Open Tag Reconstruction
+            try w.writeByte('<');
+            try w.writeAll(tag_name);
 
-        try writeTagWithNewAttr(w, tag_content, "href", scratch.items);
-        return true;
+            const TagType = enum { img, a, other };
+            const tag_type: TagType = if (std.mem.eql(u8, tag_name, "img")) .img
+                                      else if (std.mem.eql(u8, tag_name, "a")) .a
+                                      else .other;
+
+            var it = node.startTagIterator(src, .html);
+            while (it.next(src)) |attr| {
+                const name = attr.name.slice(src);
+                // Default value is the original slice
+                var val_slice = if (attr.value) |v| v.span.slice(src) else "";
+                var needs_free = false;
+                defer if (needs_free) gpa.free(val_slice);
+
+                // 3. Attribute Transformation
+                if (std.mem.eql(u8, name, "id")) {
+                    // Prefix ID: page_url + "-" + original_id
+                    val_slice = try std.fmt.allocPrint(gpa, "{s}-{s}", .{ page_url, val_slice });
+                    needs_free = true;
+
+                } else {
+                    switch (tag_type) {
+                        .img => if (std.mem.eql(u8, name, "src")) {
+                             // Embed Image: resolve path -> base64
+                             if (!std.mem.startsWith(u8, val_slice, "http://") and !std.mem.startsWith(u8, val_slice, "https://")) {
+                                 if (try resolveRawPath(gpa, val_slice, build, page)) |abs_path| {
+                                     defer gpa.free(abs_path);
+                                     if (try embedImageToString(gpa, abs_path)) |b64| {
+                                         val_slice = b64;
+                                         needs_free = true;
+                                     }
+                                 }
+                             }else{
+                                 std.debug.print("error: Unsupport online images", .{});
+                             }
+                        },
+                        .a => if (std.mem.eql(u8, name, "href")) {
+                            // Fix Links: adjust anchors and relative paths
+                            if (std.mem.startsWith(u8, val_slice, "#")) {
+                                val_slice = try std.fmt.allocPrint(gpa, "#{s}-{s}", .{ page_url, val_slice[1..] });
+                                needs_free = true;
+                            } else if (std.mem.startsWith(u8, val_slice, "/")) {
+                                const path_part = val_slice[1..];
+                                if (std.mem.indexOf(u8, path_part, "#")) |hash_pos| {
+                                    val_slice = try std.fmt.allocPrint(gpa, "{s}-{s}", .{ val_slice[1 .. hash_pos + 1], path_part[hash_pos + 1 ..] });
+                                    needs_free = true;
+                                } else {
+                                    var processed = val_slice;
+                                    if (processed.len > 1 and processed[processed.len - 1] == '/') {
+                                        processed = processed[0 .. processed.len - 1];
+                                    }
+                                    val_slice = try std.fmt.allocPrint(gpa, "#{s}", .{processed});
+                                    needs_free = true;
+                                }
+                            }
+                        },
+                        .other => {},
+                    }
+                }
+
+                // Write attribute
+                try w.writeByte(' ');
+                try w.writeAll(name);
+                if (attr.value != null) {
+                    try w.print("=\"{s}\"", .{val_slice});
+                }
+            }
+
+            try w.writeByte('>');
+
+            // Special handling for <pre> or <code> to dump raw content
+            if (std.mem.eql(u8, tag_name, "pre") or std.mem.eql(u8, tag_name, "code")) {
+                if (node.close.start > node.open.end) {
+                    try w.writeAll(src[node.open.end..node.close.start]);
+                }
+                try w.print("</{s}>", .{tag_name});
+                return; // Do not recurse into children for <pre>/<code>
+            }
+
+            // General case for other elements: recurse children without gap-filling
+            if (!isVoid(tag_name)) {
+                var child_idx = node.first_child_idx;
+                while (child_idx != 0) {
+                    try renderNode(gpa, ast, child_idx, build, page, src, w, page_url);
+                    child_idx = ast.nodes[child_idx].next_idx;
+                }
+                try w.print("</{s}>", .{tag_name});
+            }
+        },
     }
+}
 
+// --- Helpers ---
+
+//getNodeEnd is no longer needed
+
+fn isVoid(tag_name: []const u8) bool {
+    const void_tags = &[_][]const u8{
+        "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source", "track", "wbr"
+    };
+    for (void_tags) |t| {
+        if (std.mem.eql(u8, tag_name, t)) return true;
+    }
     return false;
-}
-
-
-const Span = struct {
-    start: usize,
-    end: usize,
-};
-
-pub fn findAttrSpan(tag: []const u8, attr: []const u8) ?Span {
-    var i: usize = 0;
-    while (i < tag.len) {
-        const start = std.mem.indexOfPos(u8, tag, i, attr) orelse return null;
-        if (start > 0 and (std.ascii.isAlphanumeric(tag[start - 1]) or tag[start - 1] == '-')) {
-            i = start + 1;
-            continue;
-        }
-        var cursor = start + attr.len;
-        if (cursor < tag.len and tag[cursor] != ' ' and tag[cursor] != '=') {
-            i = start + 1;
-            continue;
-        }
-        while (cursor < tag.len and tag[cursor] == ' ') cursor += 1;
-        if (cursor >= tag.len or tag[cursor] != '=') return null;
-        cursor += 1;
-        while (cursor < tag.len and tag[cursor] == ' ') cursor += 1;
-        if (cursor >= tag.len) return null;
-
-        const q = tag[cursor];
-        if (q == '"' or q == '\'') {
-            cursor += 1;
-            const val_start = cursor;
-            while (cursor < tag.len and tag[cursor] != q) cursor += 1;
-            return Span{ .start = val_start, .end = cursor };
-        } else {
-            const val_start = cursor;
-            while (cursor < tag.len and tag[cursor] != ' ' and tag[cursor] != '>') cursor += 1;
-            return Span{ .start = val_start, .end = cursor };
-        }
-    }
-    return null;
-}
-
-pub fn findAttrValue(tag: []const u8, attr: []const u8) ?[]const u8 {
-    if (findAttrSpan(tag, attr)) |span| {
-        return tag[span.start..span.end];
-    }
-    return null;
-}
-
-pub fn writeTagWithNewAttr(w: anytype, tag: []const u8, attr: []const u8, new_val: []const u8) !void {
-    if (findAttrSpan(tag, attr)) |span| {
-        try w.writeAll(tag[0..span.start]);
-        try w.writeAll(new_val);
-        try w.writeAll(tag[span.end..]);
-    } else {
-        try w.writeAll(tag);
-    }
 }
 
 pub fn embedCss(
@@ -276,66 +179,46 @@ pub fn embedCss(
 ) !bool {
     const extension = std.fs.path.extension(path);
     if (!std.mem.eql(u8, extension, ".css")) {
-        log.warn("Unsupported css extension: {s}", .{path});
+        std.debug.print("warning: Unsupported css extension: {s}\n", .{path});
         return false;
     }
 
     const file = try dir.openFile(path, .{});
     defer file.close();
-
-    // Get file size first
-    const file_size = try file.getEndPos();
-
-    // Allocate buffer for file content
-    const content = try gpa.alloc(u8, file_size);
+    const content = try file.readToEndAlloc(gpa, std.math.maxInt(usize));
     defer gpa.free(content);
-
-    // Read entire file
-    _ = try file.readAll(content);
 
     try w.print("<style>\n{s}\n</style>", .{content});
     return true;
 }
 
-pub fn embedImage(
-    gpa: std.mem.Allocator,
-    abs_path: []const u8, // Expecting absolute path or path relative to cwd
-    w: anytype,
-) !bool {
+fn embedImageToString(gpa: std.mem.Allocator, abs_path: []const u8) !?[]const u8 {
     const extension = std.fs.path.extension(abs_path);
-    if (extension.len < 2) return false;
+    if (extension.len < 2) return null;
 
-    const mime_enum = mime.extension_map.get(extension) orelse return false;
+    const mime_enum = mime.extension_map.get(extension) orelse return null;
     const mime_type = @tagName(mime_enum);
-    if (!std.mem.startsWith(u8, mime_type, "image/")){
-        log.warn("Unsupported mime type of images: {s}", .{mime_type});
-        return false;
+    if (!std.mem.startsWith(u8, mime_type, "image/")) {
+        std.debug.print("warning: Unsupported mime type of images: {s}\n", .{mime_type});
+        return null;
     }
 
-    const file = try std.fs.openFileAbsolute(abs_path, .{});
+    const file = std.fs.openFileAbsolute(abs_path, .{}) catch return null;
     defer file.close();
 
-    // Get file size first
-    const file_size = try file.getEndPos();
+    const file_size = file.getEndPos() catch return null;
+    const file_content = try file.readToEndAlloc(gpa, file_size);
+    defer gpa.free(file_content);
 
-    // Calculate base64 encoded size
     const b64_len = std.base64.standard.Encoder.calcSize(file_size);
+    const prefix = try std.fmt.allocPrint(gpa, "data:{s};base64,", .{mime_type});
+    const total_len = prefix.len + b64_len;
 
-    // Allocate single buffer for both file content and base64
-    const buffer = try gpa.alloc(u8, b64_len);
-    defer gpa.free(buffer);
+    const buffer = try gpa.alloc(u8, total_len);
+    @memcpy(buffer[0..prefix.len], prefix);
+    _ = std.base64.standard.Encoder.encode(buffer[prefix.len..], file_content);
 
-    // Store file content at the end of the buffer
-    const file_content_start = b64_len - file_size;
-    const file_content = buffer[file_content_start..];
-    _ = try file.readAll(file_content);
-
-    // Encode base64 to the beginning of the buffer
-    _ = std.base64.standard.Encoder.encode(buffer, file_content);
-
-    try w.print("data:{s};base64,{s}", .{ mime_type, buffer });
-
-    return true;
+    return buffer;
 }
 
 pub fn resolveRawPath(
@@ -348,25 +231,20 @@ pub fn resolveRawPath(
 
     const base_dir_path = build.base_dir_path;
 
-    // Check if it's a build asset first
     if (build.build_assets.get(path)) |build_asset| {
         return try std.fs.path.join(gpa, &.{ base_dir_path, build_asset.input_path });
     }
 
     if (path[0] == '/') {
-        // Site asset
         const assets_dir_path = build.cfg.getAssetsDirPath();
         return try std.fs.path.join(gpa, &.{ base_dir_path, assets_dir_path, path[1..] });
     } else {
-        // Page asset (relative)
         const v = build.variants[page._scan.variant_id];
         const content_dir_path = v.content_dir_path;
-
         const page_dir_path = try std.fmt.allocPrint(gpa, "{f}", .{
             page._scan.file.path.fmt(&v.string_table, &v.path_table, null, false),
         });
         defer gpa.free(page_dir_path);
-
         return try std.fs.path.join(gpa, &.{ base_dir_path, content_dir_path, page_dir_path, path });
     }
 }

--- a/src/root.zig
+++ b/src/root.zig
@@ -11,7 +11,7 @@ const supermd = @import("supermd");
 const fatal = @import("fatal.zig");
 const worker = @import("worker.zig");
 const context = @import("context.zig");
-const Build = @import("Build.zig");
+pub const Build = @import("Build.zig");
 const Variant = @import("Variant.zig");
 const StringTable = @import("StringTable.zig");
 const String = StringTable.String;
@@ -21,6 +21,12 @@ const PathName = PathTable.PathName;
 
 pub var progress_buf: [4096]u8 = undefined;
 pub var progress: std.Progress.Node = undefined;
+
+pub const ExportOptions = struct {
+    custom_styles: []const []const u8 = &.{},
+    output_dir: []const u8 = "dist",
+    output_name: []const u8 = "index.html",
+};
 
 pub const Site = struct {
     /// Title of the website
@@ -61,6 +67,7 @@ pub const Site = struct {
     ///    height: auto;
     /// }
     image_size_attributes: bool = false,
+    @"export": ExportOptions = .{},
 };
 
 pub const MultilingualSite = struct {
@@ -115,6 +122,7 @@ pub const MultilingualSite = struct {
     ///    height: auto;
     /// }
     image_size_attributes: bool = false,
+    @"export": ExportOptions = .{},
 };
 
 /// A localized variant of a multilingual website
@@ -431,6 +439,7 @@ pub const Options = struct {
     base_dir_path: []const u8,
     mode: Mode,
     drafts: bool,
+    is_export_mode: bool = false,
 
     pub const Mode = union(enum) {
         memory,


### PR DESCRIPTION
This PR introduces a new `export` sub-command to Zine, enabling the generation of a **single self-contained HTML file**. All images are embedded directly into the HTML (as base64 data URIs), eliminating external dependencies. The resulting file can then be easily converted to PDF using standard tools (e.g., browser print-to-PDF or dedicated PDF renderers).

#### Key Notes
- **Embedded images**: All images are inlined into the single HTML file for full portability.
- **Unique page IDs**: Each page/section is assigned a unique ID, enabling reliable internal linking.
- **Internal link processing**: Links are rewritten to contain page path infomation, allowing seamless navigation/jumping within the single file.
- **Build context function**: Added `Build.isExportMode()` to templates, providing finer-grained control (e.g., conditional logic specific to export mode).
- **Export configuration in `zine.ziggy`**: New `export` prototype with options for:
  - Output directory
  - Output filename
  - Custom CSS paths (enables tailored styles for better PDF rendering)

#### Important Notes
In export mode:
- External links and scripts are ignored/removed for security and self-containment.
- CSS must be explicitly defined via the custom CSS paths in the `export` prototype of your `zine.ziggy` config file.

This feature greatly improves offline sharing and PDF generation workflows for Zine sites!