### PR TITLE
Add `zine new` subcommand to create page with frontmatter pre-filled

### DIFF
--- a/src/cli/new.zig
+++ b/src/cli/new.zig
@@ -1,0 +1,273 @@
+const std = @import("std");
+const Allocator = std.mem.Allocator;
+const ArrayList = std.ArrayList;
+const builtin = @import("builtin");
+
+const DateTime = @import("../context/DateTime.zig");
+const fatal = @import("../fatal.zig");
+const root = @import("../root.zig");
+
+const log = std.log.scoped(.init);
+
+pub fn new_page(gpa: Allocator, args: []const []const u8) bool {
+    errdefer |err| switch (err) {
+        error.OutOfMemory => fatal.oom(),
+    };
+
+    const cfg, _ = root.Config.load(gpa);
+    const cmd: Command = .parse(gpa, args, cfg.Site.default_frontmatter);
+
+    var date_str: std.Io.Writer.Allocating = .init(gpa);
+    errdefer date_str.deinit();
+
+    DateTime.initNow()._inst.time().strftime(&date_str.writer, "%Y-%m-%dT%H:%M:%S%z") catch |err| {
+        fatal.msg("error while trying to set date: {s}\n", .{@errorName(err)});
+    };
+    const draft_str = if (cmd.draft) "true" else "false";
+
+    var tags_list: ArrayList(u8) = .empty;
+    try tags_list.append(gpa, '[');
+    if (cmd.tags.len > 0) {
+        for (cmd.tags) |tag| {
+            try tags_list.append(gpa, '"');
+            try tags_list.appendSlice(gpa, tag);
+            try tags_list.appendSlice(gpa, "\",");
+        }
+        // pop off the last trailing comma
+        _ = tags_list.pop();
+    }
+    try tags_list.append(gpa, ']');
+
+    var alias_list: ArrayList(u8) = .empty;
+    try alias_list.append(gpa, '[');
+    if (cmd.aliases.len > 0) {
+        for (cmd.aliases) |alias| {
+            try alias_list.append(gpa, '"');
+            try alias_list.appendSlice(gpa, alias);
+            try alias_list.appendSlice(gpa, "\",");
+        }
+        // pop off the last trailing comma
+        _ = alias_list.pop();
+    }
+    try alias_list.append(gpa, ']');
+
+    const frontmatter = try std.fmt.allocPrint(gpa,
+        \\---
+        \\.title = "{s}",
+        \\.date = @date("{s}"),
+        \\.author = "{s}",
+        \\.layout = "{s}",
+        \\.draft = {s},
+        \\.description = "{s}",
+        \\.tags = {s},
+        \\.aliases = {s},
+        \\---
+    , .{ cmd.title, try date_str.toOwnedSlice(), cmd.author, cmd.layout, draft_str, cmd.description, tags_list.items, alias_list.items });
+
+    // create file and populate frontmatter according to what is in the command
+    // NOTE: this requires including the `.smd` file extension for a non-directory path,
+    // it is not appended automatically.
+    const out_file = switch (cmd.file_path[cmd.file_path.len - 1]) {
+        '/' => dir_blk: {
+            std.fs.cwd().makeDir(cmd.file_path) catch |err| {
+                fatal.msg("error while creating output file directory: {s}\n{s}\n", .{ cmd.file_path, @errorName(err) });
+            };
+            break :dir_blk try std.mem.concat(gpa, u8, &.{ cmd.file_path, "index.smd" });
+        },
+        else => cmd.file_path,
+    };
+    const new_file = std.fs.cwd().createFile(out_file, .{ .exclusive = true }) catch |err| {
+        fatal.msg("error while creating output file: {s}\n{s}\n", .{ out_file, @errorName(err) });
+    };
+    defer new_file.close();
+    new_file.writeAll(frontmatter) catch |err| fatal.file(
+        out_file,
+        err,
+    );
+
+    return false;
+}
+
+const Command = struct {
+    file_path: []const u8,
+    title: []const u8,
+    description: []const u8,
+    author: []const u8,
+    tags: []const []const u8,
+    aliases: []const []const u8,
+    draft: bool,
+    layout: []const u8,
+    fn parseCommaArray(gpa: Allocator, arg: []const u8) []const []const u8 {
+        errdefer |err| switch (err) {
+            error.OutOfMemory => fatal.oom(),
+        };
+
+        if (arg.len <= 0) {
+            fatal.msg("error: missing argument to '--tags='", .{});
+        }
+
+        if (std.mem.indexOfScalar(u8, arg, ',') == null) {
+            return &.{arg};
+        } else {
+            var tagArr: std.ArrayList([]const u8) = .empty;
+            defer tagArr.deinit(gpa);
+
+            var tagIt = std.mem.tokenizeScalar(u8, arg, ',');
+            while (tagIt.next()) |tag| {
+                try tagArr.append(gpa, tag);
+            }
+
+            return try tagArr.toOwnedSlice(gpa);
+        }
+    }
+
+    fn parse(gpa: Allocator, args: []const []const u8, default_config: ?DefaultFrontmatter) Command {
+        var file_path: []const u8 = undefined;
+        var title: ?[]const u8 = default_config.?.title;
+        var description: ?[]const u8 = default_config.?.description;
+        var author: ?[]const u8 = default_config.?.author;
+        var tags: ?[]const []const u8 = default_config.?.tags;
+        var aliases: ?[]const []const u8 = default_config.?.aliases;
+        var draft: ?bool = default_config.?.draft;
+        var layout: ?[]const u8 = default_config.?.layout;
+
+        if (args.len <= 0) {
+            fatal.msg("Must provide a file path to 'zine new'", .{});
+        }
+
+        // In order:
+        // 1. attempt to parse values for all fields above from CLI args
+        // 2. for any that are still unpopulated, fall back to values from the config file
+        // set above
+        // 3. finally, set to a reasonable default (e.g. empty string) if neither of the above resolves
+        var idx: usize = 0;
+        while (idx < args.len) : (idx += 1) {
+            const arg = args[idx];
+
+            if (std.mem.eql(u8, arg, "-h") or std.mem.eql(u8, arg, "--help")) {
+                helpMsg();
+            }
+
+            if (std.mem.startsWith(u8, arg, "--title=")) {
+                title = arg["--title=".len..];
+            } else if (std.mem.eql(u8, arg, "--title")) {
+                idx += 1;
+                if (idx >= args.len) fatal.msg(
+                    "error: missing argument to '--title'",
+                    .{},
+                );
+                title = args[idx];
+            } else if (std.mem.startsWith(u8, arg, "--description=")) {
+                description = arg["--description=".len..];
+            } else if (std.mem.startsWith(u8, arg, "--description")) {
+                idx += 1;
+                if (idx >= args.len) fatal.msg(
+                    "error: missing argument to '--description'",
+                    .{},
+                );
+                description = args[idx];
+            } else if (std.mem.startsWith(u8, arg, "--author=")) {
+                author = arg["--author=".len..];
+            } else if (std.mem.startsWith(u8, arg, "--author")) {
+                idx += 1;
+                if (idx >= args.len) fatal.msg(
+                    "error: missing argument to '--author'",
+                    .{},
+                );
+                author = args[idx];
+            } else if (std.mem.startsWith(u8, arg, "--layout=")) {
+                layout = arg["--layout=".len..];
+            } else if (std.mem.startsWith(u8, arg, "--layout")) {
+                idx += 1;
+                if (idx >= args.len) fatal.msg(
+                    "error: missing argument to '--layout'",
+                    .{},
+                );
+                layout = args[idx];
+            } else if (std.mem.startsWith(u8, arg, "--tags=")) {
+                // tags and aliases are comma separated
+                const suffix = arg["--tags=".len..];
+                tags = parseCommaArray(gpa, suffix);
+            } else if (std.mem.startsWith(u8, arg, "--tags")) {
+                idx += 1;
+                if (idx >= args.len) fatal.msg(
+                    "error: missing argument to '--tags'",
+                    .{},
+                );
+                tags = parseCommaArray(gpa, args[idx]);
+            } else if (std.mem.startsWith(u8, arg, "--aliases=")) {
+                // tags and aliases are comma separated
+                const suffix = arg["--aliases=".len..];
+                aliases = parseCommaArray(gpa, suffix);
+            } else if (std.mem.startsWith(u8, arg, "--aliases")) {
+                idx += 1;
+                if (idx >= args.len) fatal.msg(
+                    "error: missing argument to '--tags'",
+                    .{},
+                );
+                aliases = parseCommaArray(gpa, args[idx]);
+            } else if (std.mem.startsWith(u8, arg, "--draft")) {
+                // NOTE: chose to just have this be present as a boolean flag rather than
+                // explicitly providing a vaule to the option.
+                draft = true;
+            }
+
+            // Last argument must be the file path
+            file_path = arg;
+        }
+
+        return .{
+            .file_path = file_path,
+            .title = title orelse "Untitled",
+            .description = description orelse "",
+            .author = author orelse "",
+            .tags = tags orelse &.{},
+            .aliases = aliases orelse &.{},
+            .draft = draft orelse true,
+            // Default from `zine init`
+            .layout = layout orelse "post.shtml",
+        };
+    }
+
+    fn helpMsg() void {
+        fatal.msg(
+            \\Create a new page at the given path with frontmatter pre-filled. Frontmatter will be populated using, in prioritized order:
+            \\  1. CLI options for the invocation of this command
+            \\  2. Values set in the `.default_frontmatter` field of the site's `zine.ziggy` config file
+            \\  3. A standard default
+            \\
+            \\Usage: zine new [OPTIONS] [PATH]
+            \\
+            \\Command specific options:
+            \\  --title          Set the title for the new page
+            \\  --description    Set the "description" frontmatter field for the new page
+            \\  --author         Set the "author" frontmatter field for the new page
+            \\  --tags           Set the "tags" frontmatter field for the new page, provide a comma separated list of tags.
+            \\  --aliases        Set the "aliases" frontmatter field for the new page, provide a comma separated list of tags.
+            \\  --draft          Set the "draft" frontmatter field for the new page
+            \\  --layout         Set the "layout" frontmatter field for the new page
+            \\
+            \\Positional Arguments:
+            \\  PATH (required): the path to the new file to create. May be an explicit
+            \\    full file path, or a directory path with a trailing '/' character. If the latter
+            \\    is provided, an `index.smd` file will be automatically created in that directory
+            \\
+            \\General Options:
+            \\  --help, -h       Print command specific usage
+            \\
+            \\Examples:
+            \\  `zine new --title "A New Post" --tags "tag1,tag2" --draft=true content/blog/new-post.smd`
+            \\  `zine new --title "Another New Post" --layout "post.shtml" content/blog/another-new-post/`
+        , .{});
+    }
+};
+
+pub const DefaultFrontmatter = struct {
+    title: ?[]const u8 = null,
+    description: ?[]const u8 = null,
+    author: ?[]const u8 = null,
+    tags: ?[]const []const u8 = null,
+    aliases: ?[]const []const u8 = null,
+    draft: ?bool = null,
+    layout: []const u8,
+};

--- a/src/cli/serve/watcher/LinuxWatcher.zig
+++ b/src/cli/serve/watcher/LinuxWatcher.zig
@@ -300,7 +300,7 @@ pub fn listen(watcher: *LinuxWatcher) !void {
 
         var event_data = buffer[0..len];
         while (event_data.len > 0) {
-            const event: *Event = @alignCast(@ptrCast(event_data[0..event_size]));
+            const event: *Event = @ptrCast(@alignCast(event_data[0..event_size]));
             const parent = watcher.watch_fds.get(event.wd).?;
             event_data = event_data[event_size + event.len ..];
 

--- a/src/cli/serve/watcher/MacosWatcher.zig
+++ b/src/cli/serve/watcher/MacosWatcher.zig
@@ -98,9 +98,9 @@ pub fn macosCallback(
     _ = eventIds;
     _ = eventFlags;
     _ = streamRef;
-    const watcher: *MacosWatcher = @alignCast(@ptrCast(clientCallBackInfo));
+    const watcher: *MacosWatcher = @ptrCast(@alignCast(clientCallBackInfo));
 
-    const paths: [*][*:0]u8 = @alignCast(@ptrCast(eventPaths));
+    const paths: [*][*:0]u8 = @ptrCast(@alignCast(eventPaths));
     for (paths[0..numEvents]) |p| {
         const path = std.mem.span(p);
         log.debug("Changed: {s}\n", .{path});

--- a/src/context/Page.zig
+++ b/src/context/Page.zig
@@ -472,14 +472,14 @@ pub const Alternative = struct {
             \\of the page.
         ;
         pub const @"type" =
-            \\A metadata field that can be used to set the content-type of this alternative version of the Page. 
+            \\A metadata field that can be used to set the content-type of this alternative version of the Page.
             \\
             \\Useful for example to generate RSS links:
             \\
             \\```superhtml
             \\<ctx alt="$page.alternative('rss')">
-            \\  <a href="$ctx.alt.link()" 
-            \\     type="$ctx.alt.type" 
+            \\  <a href="$ctx.alt.link()"
+            \\     type="$ctx.alt.type"
             \\     :text="$ctx.alt.name"
             \\  ></a>
             \\</ctx>
@@ -594,65 +594,65 @@ pub const docs_description =
 ;
 pub const Fields = struct {
     pub const title =
-        \\Title of the page, 
+        \\Title of the page,
         \\as set in the SuperMD frontmatter.
     ;
     pub const description =
-        \\Description of the page, 
+        \\Description of the page,
         \\as set in the SuperMD frontmatter.
     ;
     pub const author =
-        \\Author of the page, 
+        \\Author of the page,
         \\as set in the SuperMD frontmatter.
     ;
     pub const date =
-        \\Publication date of the page, 
+        \\Publication date of the page,
         \\as set in the SuperMD frontmatter.
         \\
         \\Used to provide default ordering of pages.
     ;
     pub const layout =
-        \\SuperHTML layout used to render the page, 
+        \\SuperHTML layout used to render the page,
         \\as set in the SuperMD frontmatter.
     ;
     pub const draft =
-        \\When set to true the page will not be rendered in release mode, 
+        \\When set to true the page will not be rendered in release mode,
         \\as set in the SuperMD frontmatter.
     ;
     pub const tags =
-        \\Tags associated with the page, 
+        \\Tags associated with the page,
         \\as set in the SuperMD frontmatter.
     ;
     pub const aliases =
-        \\Aliases of the current page, 
+        \\Aliases of the current page,
         \\as set in the SuperMD frontmatter.
         \\
         \\Aliases can be used to make the same page available
         \\from different locations.
         \\
-        \\Every entry in the list is an output location where the 
+        \\Every entry in the list is an output location where the
         \\rendered page will be copied to.
     ;
     pub const alternatives =
-        \\Alternative versions of the page, 
+        \\Alternative versions of the page,
         \\as set in the SuperMD frontmatter.
         \\
         \\Alternatives are a good way of implementing RSS feeds, for example.
     ;
     pub const skip_subdirs =
-        \\Skips any other potential content present in the subdir of the page, 
+        \\Skips any other potential content present in the subdir of the page,
         \\as set in the SuperMD frontmatter.
         \\
         \\Can only be set to true on section pages (i.e. `index.smd` pages).
     ;
     pub const translation_key =
-        \\Translation key used to map this page with corresponding localized variants, 
+        \\Translation key used to map this page with corresponding localized variants,
         \\as set in the SuperMD frontmatter.
         \\
         \\See the docs on i18n for more info.
     ;
     pub const custom =
-        \\A Ziggy map where you can define custom properties for the page, 
+        \\A Ziggy map where you can define custom properties for the page,
         \\as set in the SuperMD frontmatter.
     ;
 };
@@ -660,10 +660,10 @@ pub const Builtins = struct {
     pub const isCurrent = struct {
         pub const signature: Signature = .{ .ret = .Bool };
         pub const docs_description =
-            \\Returns true if the target page is the one currently being 
-            \\rendered. 
+            \\Returns true if the target page is the one currently being
+            \\rendered.
             \\
-            \\To be used in conjunction with the various functions that give 
+            \\To be used in conjunction with the various functions that give
             \\you references to other pages, like `$site.page()`, for example.
         ;
         pub const examples =
@@ -689,7 +689,7 @@ pub const Builtins = struct {
         pub const docs_description =
             \\Retuns an asset by name from inside the page's asset directory.
             \\
-            \\Assets for a non-section page must be placed under a subdirectory 
+            \\Assets for a non-section page must be placed under a subdirectory
             \\that shares the same name with the corresponding markdown file.
             \\
             \\(as a reminder sections are defined by pages named `index.smd`)
@@ -1076,9 +1076,9 @@ pub const Builtins = struct {
     pub const parentSection = struct {
         pub const signature: Signature = .{ .ret = .Page };
         pub const docs_description =
-            \\Returns the parent section of a page. 
+            \\Returns the parent section of a page.
             \\
-            \\It's always an error to call this function on the site's main 
+            \\It's always an error to call this function on the site's main
             \\index page as it doesn't have a parent section.
         ;
         pub const examples =
@@ -1107,7 +1107,7 @@ pub const Builtins = struct {
     pub const isSection = struct {
         pub const signature: Signature = .{ .ret = .Bool };
         pub const docs_description =
-            \\Returns true if the current page defines a section (i.e. if 
+            \\Returns true if the current page defines a section (i.e. if
             \\the current page is an 'index.smd' page).
             \\
         ;
@@ -1129,10 +1129,10 @@ pub const Builtins = struct {
     pub const subpages = struct {
         pub const signature: Signature = .{ .ret = .{ .Many = .Page } };
         pub const docs_description =
-            \\Returns a list of all the pages in this section. If the page is 
+            \\Returns a list of all the pages in this section. If the page is
             \\not a section, returns an empty list.
             \\
-            \\Sections are defined by `index.smd` files, see the content 
+            \\Sections are defined by `index.smd` files, see the content
             \\structure section in the official docs for more info.
         ;
         pub const examples =
@@ -1171,7 +1171,7 @@ pub const Builtins = struct {
         pub const signature: Signature = .{ .ret = .{ .Many = .Page } };
         pub const docs_description =
             \\Same as `subpages`, but returns the pages in alphabetic order by
-            \\comparing their titles. 
+            \\comparing their titles.
         ;
         pub const examples =
             \\<div :loop="$page.subpagesAlphabetic()">
@@ -1217,9 +1217,9 @@ pub const Builtins = struct {
     pub const @"nextPage?" = struct {
         pub const signature: Signature = .{ .ret = .{ .Opt = .Page } };
         pub const docs_description =
-            \\Returns the next page in the same section, sorted by date. 
+            \\Returns the next page in the same section, sorted by date.
             \\
-            \\The returned value is an optional to be used in conjunction 
+            \\The returned value is an optional to be used in conjunction
             \\with an `if` attribute. Use `$if` to access the unpacked value
             \\within the `if` block.
         ;
@@ -1304,7 +1304,7 @@ pub const Builtins = struct {
     pub const hasNext = struct {
         pub const signature: Signature = .{ .ret = .Bool };
         pub const docs_description =
-            \\Returns true of the target page has another page after (sorted by date) 
+            \\Returns true of the target page has another page after (sorted by date)
         ;
         pub const examples =
             \\$page.hasNext()
@@ -1346,7 +1346,7 @@ pub const Builtins = struct {
     pub const hasPrev = struct {
         pub const signature: Signature = .{ .ret = .Bool };
         pub const docs_description =
-            \\Returns true of the target page has another page before (sorted by date) 
+            \\Returns true of the target page has another page before (sorted by date)
         ;
         pub const examples =
             \\$page.hasPrev()
@@ -1432,11 +1432,11 @@ pub const Builtins = struct {
             .ret = .String,
         };
         pub const docs_description =
-            \\Returns the URL of the target page, allowing you 
+            \\Returns the URL of the target page, allowing you
             \\to specify a fragment id to deep-link to a specific
             \\element of the content page.
             \\
-            \\The id will be checked by Zine and an error will be  
+            \\The id will be checked by Zine and an error will be
             \\reported if it does not exist.
             \\
             \\See the SuperMD reference documentation to learn how to give
@@ -1502,8 +1502,8 @@ pub const Builtins = struct {
         ;
         pub const examples =
             \\<ctx alt="$page.alternative('rss')">
-            \\  <a href="$ctx.alt.link()" 
-            \\     type="$ctx.alt.type" 
+            \\  <a href="$ctx.alt.link()"
+            \\     type="$ctx.alt.type"
             \\     :text="$ctx.alt.name"
             \\  ></a>
         ;
@@ -1672,7 +1672,7 @@ pub const Builtins = struct {
             \\Returns a list of sections for the current page.
             \\
             \\A page that doesn't define any section will have
-            \\a default section for the whole document with a 
+            \\a default section for the whole document with a
             \\null id.
         ;
         pub const examples =
@@ -1810,7 +1810,7 @@ pub const ContentSection = struct {
             pub const signature: Signature = .{ .ret = .String };
             pub const docs_description =
                 \\If the section starts with a heading element,
-                \\this function returns the heading as simple text.           
+                \\this function returns the heading as simple text.
             ;
             pub const examples =
                 \\<div :html="$loop.it.heading()"></div>
@@ -1843,7 +1843,7 @@ pub const ContentSection = struct {
             pub const signature: Signature = .{ .ret = .{ .Opt = .String } };
             pub const docs_description =
                 \\If the section starts with a heading element,
-                \\this function returns the heading as simple text.           
+                \\this function returns the heading as simple text.
             ;
             pub const examples =
                 \\<div :html="$loop.it.heading()"></div>

--- a/src/fatal.zig
+++ b/src/fatal.zig
@@ -28,6 +28,7 @@ pub fn help() noreturn {
         \\  (no command)      Start the development web server
         \\  init              Initialize a Zine site in the current directory
         \\  release           Create a release of a Zine site
+        \\  new               Create a new page
         \\  help              Show this menu and exit
         \\  version           Print the Zine version and exit
         \\
@@ -35,7 +36,7 @@ pub fn help() noreturn {
         \\  --drafts          Enable draft pages
         \\  --help, -h        Print command specific usage and extra options
         \\
-        \\Development web server options: 
+        \\Development web server options:
         \\  --host HOST       Listening host (default 'localhost')
         \\  --port PORT       Listening port (default 1990)
         \\  --debounce <ms>   Rebuild delay after a file change (default 25)

--- a/src/main.zig
+++ b/src/main.zig
@@ -96,7 +96,7 @@ pub fn main() u8 {
             \\| Thread sanitizer introduces a significant     |
             \\| performance overhead.                         |
             \\|                                               |
-            \\| If you're not interested in debugging         |  
+            \\| If you're not interested in debugging         |
             \\| concurrency bugs in Zine, remove `-Dtsan`     |
             \\| when building again.                          |
             \\*-----------------------------------------------*

--- a/src/main.zig
+++ b/src/main.zig
@@ -16,6 +16,7 @@ pub const std_options: std.Options = .{
 
 const Command = enum {
     init,
+    new,
     release,
     debug,
     help,
@@ -119,6 +120,7 @@ pub fn main() u8 {
 
     const any_error = switch (cmd) {
         .init => @import("cli/init.zig").init(gpa, args[2..]),
+        .new => @import("cli/new.zig").new_page(gpa, args[2..]),
         .release => @import("cli/release.zig").release(gpa, args[2..]),
         .debug => @import("cli/debug.zig").debug(gpa, args[2..]),
         .help, .@"-h", .@"--help" => fatal.help(),

--- a/src/root.zig
+++ b/src/root.zig
@@ -1406,7 +1406,7 @@ pub fn run(
 
             const parent_name = template.ast.nodes[template.ast.extends_idx].templateValue().span.slice(template.src);
             std.debug.print(
-                \\{s}: error: extending a template that doesn't exist 
+                \\{s}: error: extending a template that doesn't exist
                 \\   template '{s}' does not exist
                 \\
             , .{
@@ -1416,7 +1416,7 @@ pub fn run(
                 try build.mode.memory.errors.append(gpa, .{
                     .ref = "",
                     .msg = try std.fmt.allocPrint(gpa,
-                        \\{s}: error: extending a template that doesn't exist 
+                        \\{s}: error: extending a template that doesn't exist
                         \\   template '{s}' does not exist
                         \\
                     , .{

--- a/src/root.zig
+++ b/src/root.zig
@@ -61,6 +61,11 @@ pub const Site = struct {
     ///    height: auto;
     /// }
     image_size_attributes: bool = false,
+
+    /// Default field settings for frontmatter created with the `zine new` subcommand.
+    /// Values here will be overridden by any options passed to an invocation of the
+    /// subcommand.
+    default_frontmatter: ?@import("cli/new.zig").DefaultFrontmatter = null,
 };
 
 pub const MultilingualSite = struct {

--- a/tests/content-scanning/templates/snapshot.txt
+++ b/tests/content-scanning/templates/snapshot.txt
@@ -24,7 +24,7 @@ content/another.smd:5:11: error: missing layout file
 |    .layout = "doesntexist-layout.shtml",
 |              ^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-layouts/badextend.shtml: error: extending a template that doesn't exist 
+layouts/badextend.shtml: error: extending a template that doesn't exist
    template 'doesntexist-template.shtml' does not exist
 layouts/badhtml.shtml:1:4: erroneous_end_tag
 layouts/badshtml.shtml:0:1: extend_without_template_attr


### PR DESCRIPTION
Resolves #34 

Thanks for making zine! It's my favorite SSG that I've used and by far the one I've stuck with for the longest (and plan to continue to stick to).

I found myself also wanting a subcommand to create a new page with frontmatter already pre-filled for me (#34), just to save a bit of the copy-paste.  I saw as well from the most recent [release notes](https://zine-ssg.io/log/#v0.11.2) that there are additional Ziggy changes coming soon, so if that ends up replacing any of this work then so be it. A few general notes:
* I'm fairly new to zig, so please tell me all the dumb things I've done. I'm sure there are myriad, especially with the file writing.
* I chose not to enforce that the `layout` provided actually exists, I figure that error will naturally bubble up when trying to build the site as normal
* I'm not sure what the best way to add tests for this is. I've tested it locally myself plenty (and have been using it myself on my zine site), so I'm fairly confident in at least the happy-path behavior. I see that there are a bunch of tests in this repo that do a git diff of the generated content to ensure correctness, if that's the way to go I'm happy to add another commit with the equivalent for this.
* I'm not married to `zine new`, that may be a bit too ambiguous. The original issue suggested `zine newpage`, which also seems fine to me. I prefer the short/single word version personally but am happy to change it if that's too short.
* The 2 commits on top of the subcommand addition are just chore cleanup. I've been working with zig `0.15.2` so there are some new auto-applied `zig fmt` changes, and one commit just drops a bunch of trailing whitespace. If those changes are going to cause a problem I'm happy to drop one or both commits

As an example of this in use, the `zine.ziggy` for my own site now contains:
```ziggy
Site {
    // ... existing ...
    .default_frontmatter = {
        .author = "My name",
        .layout = "post.shtml",
    }
}
```

and I create new posts with

```sh
zine new --title "Some readable title etc" --tags "tag1,tag2" content/blog/new-post/
```