### PR TITLE
feat: add support for audio embeds

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -51,8 +51,8 @@
             .hash = "ziggy-0.1.0-kTg8v5pABgDztlefWHceH-Sh8tVveguFC61QkmLkIRaA",
         },
         .supermd = .{
-            .url = "git+https://github.com/kristoff-it/supermd#530ac6c337c9a9511560fba3181db10d1fe23ef1",
-            .hash = "supermd-0.1.0-3Mco3GyYWACe4ptEKIrZUhizWGwXhbmtKtjNopG8f76y",
+            .url = "git+https://github.com/PowerUser64/supermd#6cb04c86f37e52ac619e8e7443e31dda8d0ffd27",
+            .hash = "supermd-0.1.0-3Mco3NWeWADjhkFaNhbeGL7QI_OfuJ-0d0EiQdorcYKr",
         },
     },
     .paths = .{"."},

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -46,8 +46,8 @@
             .hash = "ziggy-0.1.0-kTg8v3xBBgD66kzRYoOgByokYiVMupy4dew5buN45X-y",
         },
         .supermd = .{
-            .url = "git+https://github.com/kristoff-it/supermd#76a43686add44fefbb89fc30ba6fce3b4f3a356d",
-            .hash = "supermd-0.1.0-3Mco3E-XWACwqlsi-OOOSLfKyoutlDoRbjoiJ9PXOSH4",
+            .url = "git+https://github.com/kristoff-it/supermd#d92be7eb5c4807123dd9a52a88fac2ccd59c5b82",
+            .hash = "supermd-0.1.0-3Mco3LidWABc21D8DA_dn49JtwqAFos1Z9XRs88uOwas",
         },
         .translate_c = .{
             .url = "git+https://codeberg.org/kristoff/translate-c?ref=0.17.x#c01b34d1e57010019d77ffef1dbc704af870a2eb",

--- a/src/render/html.zig
+++ b/src/render/html.zig
@@ -530,7 +530,9 @@ fn renderDirective(
                 if (snd.loop) |val| if (val) try w.writeAll(" loop");
                 if (snd.autoplay) |val| if (val) try w.writeAll(" autoplay");
                 if (snd.muted) |val| if (val) try w.writeAll(" muted");
-                if (snd.controls) |val| if (val) try w.writeAll(" controls");
+                if (snd.hide_controls) |val| {
+                    if (!val) try w.writeAll(" controls");
+                } else try w.writeAll(" controls");
                 try w.writeAll(">\n<source src=\"");
                 try printUrl(ctx, page, snd.src.?, w);
                 try w.writeAll("\">\n</audio>");

--- a/src/render/html.zig
+++ b/src/render/html.zig
@@ -515,6 +515,34 @@ fn renderDirective(
                 }
             },
         },
+        .audio => |snd| switch (ev.dir) {
+            .enter => {
+                const caption = node.firstChild();
+                if (caption != null) try w.writeAll("<figure>");
+                try w.writeAll("<audio");
+                if (directive.id) |id| try w.print(" id=\"{s}\"", .{id});
+                if (directive.attrs) |attrs| {
+                    try w.writeAll(" class=\"");
+                    for (attrs) |attr| try w.print("{s} ", .{attr});
+                    try w.writeAll("\"");
+                }
+                if (directive.title) |t| try w.print(" title=\"{s}\"", .{t});
+                if (snd.loop) |val| if (val) try w.writeAll(" loop");
+                if (snd.autoplay) |val| if (val) try w.writeAll(" autoplay");
+                if (snd.muted) |val| if (val) try w.writeAll(" muted");
+                if (snd.controls) |val| if (val) try w.writeAll(" controls");
+                try w.writeAll(">\n<source src=\"");
+                try printUrl(ctx, page, snd.src.?, w);
+                try w.writeAll("\">\n</audio>");
+                if (caption != null) try w.writeAll("\n<figcaption>");
+            },
+            .exit => {
+                const caption = node.firstChild();
+                if (caption != null) {
+                    try w.writeAll("</figcaption></figure>");
+                }
+            },
+        },
         .link => |lnk| switch (ev.dir) {
             .enter => {
                 try w.writeAll("<a");

--- a/src/render/html.zig
+++ b/src/render/html.zig
@@ -516,6 +516,34 @@ fn renderDirective(
                 }
             },
         },
+        .audio => |snd| switch (ev.dir) {
+            .enter => {
+                const caption = node.firstChild();
+                if (caption != null) try w.writeAll("<figure>");
+                try w.writeAll("<audio");
+                if (directive.id) |id| try w.print(" id=\"{s}\"", .{id});
+                if (directive.attrs) |attrs| {
+                    try w.writeAll(" class=\"");
+                    for (attrs) |attr| try w.print("{s} ", .{attr});
+                    try w.writeAll("\"");
+                }
+                if (directive.title) |t| try w.print(" title=\"{s}\"", .{t});
+                if (snd.loop) |val| if (val) try w.writeAll(" loop");
+                if (snd.autoplay) |val| if (val) try w.writeAll(" autoplay");
+                if (snd.muted) |val| if (val) try w.writeAll(" muted");
+                if (snd.controls) |val| if (val) try w.writeAll(" controls");
+                try w.writeAll(">\n<source src=\"");
+                try printUrl(ctx, page, snd.src.?, w);
+                try w.writeAll("\">\n</audio>");
+                if (caption != null) try w.writeAll("\n<figcaption>");
+            },
+            .exit => {
+                const caption = node.firstChild();
+                if (caption != null) {
+                    try w.writeAll("</figcaption></figure>");
+                }
+            },
+        },
         .link => |lnk| switch (ev.dir) {
             .enter => {
                 try w.writeAll("<a");

--- a/src/render/html.zig
+++ b/src/render/html.zig
@@ -531,7 +531,9 @@ fn renderDirective(
                 if (snd.loop) |val| if (val) try w.writeAll(" loop");
                 if (snd.autoplay) |val| if (val) try w.writeAll(" autoplay");
                 if (snd.muted) |val| if (val) try w.writeAll(" muted");
-                if (snd.controls) |val| if (val) try w.writeAll(" controls");
+                if (snd.hide_controls) |val| {
+                    if (!val) try w.writeAll(" controls");
+                } else try w.writeAll(" controls");
                 try w.writeAll(">\n<source src=\"");
                 try printUrl(ctx, page, snd.src.?, w);
                 try w.writeAll("\">\n</audio>");

--- a/src/render/html.zig
+++ b/src/render/html.zig
@@ -531,9 +531,9 @@ fn renderDirective(
                 if (snd.loop) |val| if (val) try w.writeAll(" loop");
                 if (snd.autoplay) |val| if (val) try w.writeAll(" autoplay");
                 if (snd.muted) |val| if (val) try w.writeAll(" muted");
-                if (snd.hide_controls) |val| {
-                    if (!val) try w.writeAll(" controls");
-                } else try w.writeAll(" controls");
+                if (snd.hide_controls == null or !snd.hide_controls.?) {
+                    try w.writeAll(" controls");
+                }
                 try w.writeAll(">\n<source src=\"");
                 try printUrl(ctx, page, snd.src.?, w);
                 try w.writeAll("\">\n</audio>");

--- a/src/worker.zig
+++ b/src/worker.zig
@@ -491,7 +491,7 @@ fn analyzeContent(
                 directive.kind.code.src = .{ .url = snippet };
             },
 
-            // Link, Image, Video directives
+            // Link, Image, Video, Audio directives
             inline else => |*val| {
                 switch (val.src.?) {
                     .url => continue :outer,

--- a/src/worker.zig
+++ b/src/worker.zig
@@ -498,7 +498,7 @@ fn analyzeContent(
                 directive.kind.code.src = .{ .url = snippet };
             },
 
-            // Link, Image, Video directives
+            // Link, Image, Video, Audio directives
             inline else => |*val| {
                 switch (val.src.?) {
                     .url => continue :outer,


### PR DESCRIPTION
Requires: https://github.com/kristoff-it/supermd/pull/17

Based on the video implementation.

This makes it possible to embed audio assets like this:
`[](<$audio.asset('my-cool-sound.wav').controls(true)>)`

One thing I wasn't sure about was whether to copy the video embed's "no controls" default. I decided to make it show controls by default, because otherwise it wouldn't look like anything happened when you embed a file.

Let me know if you want the controls to be hidden by default, for consistency with video.

*I used no form of AI in the creation of this PR.*