### PR TITLE
Bump minimum Zig version to 0.15.2

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,7 +2,7 @@
     .name = .zine,
     .version = "0.11.2",
     .fingerprint = 0xa466bcb520a7eea2,
-    .minimum_zig_version = "0.15.0",
+    .minimum_zig_version = "0.15.2",
     .dependencies = .{
         .afl_kit = .{
             .url = "git+https://github.com/kristoff-it/zig-afl-kit#8ef04d1db48650345dca68da1e1b8f2615125c40",


### PR DESCRIPTION
Zine fails to build in Zig 0.15.0 on the following system:

 - Operating System: macos
 - Architecture: x86_64
 - CPU Model: skylake
 - Triple: x86_64-macos.15.4.1...15.4.1-none

The error seems to be related to flow-syntax:

```
 $ zig build

 install
 +- install zine
    +- compile exe zine Debug native
       +- run exe ts_bin_query_gen (bin_queries.cbor) failure
 error: stderr:

 error: the following command terminated unexpectedly:
...
 Build Summary: 17/21 steps succeeded; 1 failed
 install transitive failure
 +- install zine transitive failure
    +- compile exe zine Debug native transitive failure
       +- run exe ts_bin_query_gen (bin_queries.cbor) failure
```

But after investigating with the maintainer of flow-syntax (see: https://github.com/neurocyte/flow-syntax/pull/16), we conclude it is not an issue with flow-syntax but rather Zig bugs related to Debug builds on Intel Macs that have since been fixed. In any case, Zine builds for me in 0.15.2 so propose to bump the minimum_zig_version here.