### PR TITLE
fix: emit heading id only if present

### DIFF
--- a/src/render/html.zig
+++ b/src/render/html.zig
@@ -191,7 +191,7 @@ pub fn html(
                         else => {},
                         .heading => {
                             try w.print("<h{}", .{node.headingLevel()});
-                            try w.print(" id=\"{s}\"", .{d.id.?});
+                            if (d.id) |id| try w.print(" id=\"{s}\"", .{id});
                             if (d.attrs) |attrs| {
                                 try w.print(" class=\"", .{});
                                 for (attrs) |attr| try w.print("{s} ", .{attr});
@@ -207,7 +207,7 @@ pub fn html(
                             }
                             open_div = true;
                             try w.print("<div", .{});
-                            try w.print(" id=\"{s}\"", .{d.id.?});
+                            if (d.id) |id| try w.print(" id=\"{s}\"", .{id});
                             if (d.attrs) |attrs| {
                                 try w.print(" class=\"", .{});
                                 for (attrs) |attr| try w.print("{s} ", .{attr});


### PR DESCRIPTION
All other prongs do this so just do the same.

Without this, any smd which declares a heading without an id (e.g styled with just `attrs`) will produce IB (usually a segmentation fault)