### PR TITLE
Adding depth parameter to TOC

### DIFF
--- a/src/context/Page.zig
+++ b/src/context/Page.zig
@@ -1758,12 +1758,16 @@ pub const Builtins = struct {
     };
 
     pub const toc = struct {
-        pub const signature: Signature = .{ .ret = .String };
+        pub const signature: Signature = .{
+            .params = .{ .Opt = .{.Int} },
+            .ret = .String,
+        };
         pub const docs_description =
             \\Renders the table of content.
         ;
         pub const examples =
             \\<div :html="$page.toc()"></div>
+            \\<div :html="$page.toc(1)"></div>
         ;
         pub fn call(
             p: *const Page,
@@ -1771,16 +1775,27 @@ pub const Builtins = struct {
             _: *const context.Template,
             args: []const Value,
         ) context.CallError!Value {
-            const bad_arg: Value = .{
-                .err = "expected 0 arguments",
+            const bad_arg_nb: Value = .{
+                .err = "Expected almost 1 arg",
             };
-            if (args.len != 0) return bad_arg;
+            const bad_arg: Value = .{
+                .err = "max depth must be bigger than 0",
+            };
+            var max_depth: ?u32 = null;
+            if (args.len > 1) {
+                return bad_arg_nb;
+            } else if (args.len == 1) {
+                if (args[0].int.value < 1) {
+                    return bad_arg;
+                }
+                max_depth = @intCast(args[0].int.value);
+            }
 
             var aw: Writer.Allocating = .init(gpa);
             const w = &aw.writer;
 
             const ast = p._parse.ast;
-            render.htmlToc(ast, w) catch return error.OutOfMemory;
+            render.htmlToc(ast, w, max_depth) catch return error.OutOfMemory;
 
             return String.init(aw.written());
         }

--- a/src/render/html.zig
+++ b/src/render/html.zig
@@ -757,7 +757,7 @@ fn renderLink(
     }
 }
 
-pub fn htmlToc(ast: Ast, w: *Writer) !void {
+pub fn htmlToc(ast: Ast, w: *Writer, depth: ?u32) !void {
     try w.print("<ul>\n", .{});
     var lvl: i32 = 1;
     var first_item = true;
@@ -765,31 +765,35 @@ pub fn htmlToc(ast: Ast, w: *Writer) !void {
     while (node) |n| : (node = n.nextSibling()) {
         if (n.nodeType() != .HEADING) continue;
         defer first_item = false;
+        var max_depth: u32 = 0xFFFFFFFF;
+        if (depth) |v| max_depth = v + 1;
 
         const new_lvl = n.headingLevel();
-        if (new_lvl > lvl) {
-            if (first_item) {
-                try w.print("<li>\n", .{});
-            }
-            while (new_lvl > lvl) : (lvl += 1) {
-                try w.print("<ul><li>\n", .{});
-            }
+        if (new_lvl < max_depth) {
+            if (new_lvl > lvl) {
+                if (first_item) {
+                    try w.print("<li>\n", .{});
+                }
+                while (new_lvl > lvl) : (lvl += 1) {
+                    try w.print("<ul><li>\n", .{});
+                }
 
-            try tocRenderHeading(n, w, true);
-        } else if (new_lvl < lvl) {
-            try w.print("</li>", .{});
-            while (new_lvl < lvl) : (lvl -= 1) {
-                try w.print("</ul></li>", .{});
-            }
-            try w.print("<li>", .{});
-            try tocRenderHeading(n, w, true);
-        } else {
-            if (first_item) {
+                try tocRenderHeading(n, w, true);
+            } else if (new_lvl < lvl) {
+                try w.print("</li>", .{});
+                while (new_lvl < lvl) : (lvl -= 1) {
+                    try w.print("</ul></li>", .{});
+                }
                 try w.print("<li>", .{});
                 try tocRenderHeading(n, w, true);
             } else {
-                try w.print("</li><li>", .{});
-                try tocRenderHeading(n, w, true);
+                if (first_item) {
+                    try w.print("<li>", .{});
+                    try tocRenderHeading(n, w, true);
+                } else {
+                    try w.print("</li><li>", .{});
+                    try tocRenderHeading(n, w, true);
+                }
             }
         }
     }


### PR DESCRIPTION
# Parametrable Table Of Content

I wanted to add a *max depth* parameter to `$page.toc()`.
I implemented a working solution but I'm new to zig and to zine so I'm no sure to had correctly implmenting it.

In particularly, I must add 1 to max_depth because first heading (like: `# Header`) appears with a level of 2.  