### PR TITLE
unbreak macos build and add FreeBSD support

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -309,6 +309,11 @@ pub fn build(b: *std.Build) !void {
         else => @panic("target must be added to build.zig"),
         .linux => {},
 
+       .freebsd => {
+            // only required for FreeBSD < 15
+            // zine_exe.linkSystemLibrary("inotify");
+        },
+
         .windows => {
             zine_exe.linkSystemLibrary("ws2_32");
         },
@@ -519,8 +524,10 @@ fn setupReleaseStep(
     const targets: []const std.Target.Query = &.{
         .{ .cpu_arch = .aarch64, .os_tag = .macos },
         .{ .cpu_arch = .aarch64, .os_tag = .linux, .abi = .musl },
+        .{ .cpu_arch = .aarch64, .os_tag = .freebsd },
         .{ .cpu_arch = .x86_64, .os_tag = .macos },
         .{ .cpu_arch = .x86_64, .os_tag = .linux, .abi = .musl },
+        .{ .cpu_arch = .x86_64, .os_tag = .freebsd },
         .{ .cpu_arch = .x86_64, .os_tag = .windows },
         .{ .cpu_arch = .aarch64, .os_tag = .windows },
     };
@@ -626,6 +633,10 @@ fn setupReleaseStep(
         switch (target.result.os.tag) {
             else => @panic("target must be added to build.zig"),
             .linux => {},
+            .freebsd => {
+                // only required for FreeBSD < 15
+                // zine_exe_release.linkSystemLibrary("inotify");
+            },
             .windows => {
                 zine_exe_release.linkSystemLibrary("ws2_32");
             },

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,8 +5,8 @@
     .minimum_zig_version = "0.15.0",
     .dependencies = .{
         .afl_kit = .{
-            .url = "git+https://github.com/kristoff-it/zig-afl-kit#8ef04d1db48650345dca68da1e1b8f2615125c40",
-            .hash = "afl_kit-0.1.0-NdJ3cvscAACLEvjZTB017IAks_Uq5ux1qpA-klDe384Y",
+            .url = "git+https://github.com/kristoff-it/zig-afl-kit#395c39d5b33d999f6871a90bd731ec112d3995ca",
+            .hash = "afl_kit-0.1.0-NdJ3ch8eAABQkd1wk2W-JDCvvX5Jmnu3uJulS3lPepG7",
             .lazy = true,
         },
         .lsp_kit = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -30,7 +30,7 @@
             .hash = "wuffs-0.4.0-alpha.9+3837.20240914-3CHJgcMFAACyPvxsC7b48pJv9dPkPa4pSrB2VFbCXTfK",
         },
         .frameworks = .{
-            .url = "git+https://github.com/hexops/xcode-frameworks.git#8a1cfb373587ea4c9bb1468b7c986462d8d4e10e",
+            .url = "git+https://code.hexops.org/hexops/xcode-frameworks.git#8a1cfb373587ea4c9bb1468b7c986462d8d4e10e",
             .hash = "N-V-__8AALShqgXkvqYU6f__FrA22SMWmi2TXCJjNTO1m8XJ",
             .lazy = true,
         },

--- a/build.zig.zon2json-lock
+++ b/build.zig.zon2json-lock
@@ -105,7 +105,7 @@
   },
   "N-V-__8AALShqgXkvqYU6f__FrA22SMWmi2TXCJjNTO1m8XJ": {
     "name": "frameworks",
-    "url": "git+https://github.com/hexops/xcode-frameworks.git#8a1cfb373587ea4c9bb1468b7c986462d8d4e10e",
+    "url": "git+https://code.hexops.org/hexops/xcode-frameworks.git#8a1cfb373587ea4c9bb1468b7c986462d8d4e10e",
     "hash": "sha256-b1Ay3GfBHwubnrGi4lflPiaqGfzWtABEbEiE8+ZTL90=",
     "rev": "8a1cfb373587ea4c9bb1468b7c986462d8d4e10e"
   },

--- a/src/cli/serve.zig
+++ b/src/cli/serve.zig
@@ -24,6 +24,7 @@ const error_html = @embedFile("serve/error.html");
 const outside_html = @embedFile("serve/outside.html");
 const Watcher = switch (builtin.target.os.tag) {
     .linux => @import("serve/watcher/LinuxWatcher.zig"),
+    .freebsd => @import("serve/watcher/LinuxWatcher.zig"),
     .macos => @import("serve/watcher/MacosWatcher.zig"),
     .windows => @import("serve/watcher/WindowsWatcher.zig"),
     else => @compileError("unsupported platform"),


### PR DESCRIPTION
This is 2 separate changes. The first is needed as one of zine's dependencies deleted its github repo when it was moved to codeberg.

FreeBSD from version 15 on has a native inotify. Older versions can use a port but need to link against the libinotify. This technique can also be used for #112 but I don't have a system to test.

I had to bump afl_kit for zig 0.15.2 as well.