### PR TITLE
chore: remove trailing whitespace from init template

### DIFF
--- a/src/cli/init/assets/Temml-Local.css
+++ b/src/cli/init/assets/Temml-Local.css
@@ -74,7 +74,7 @@ menclose {
     position: relative;
     padding: 0.5ex 0ex;
   }
-  
+
     .tml-overline {
     padding: 0.1em 0 0 0;
     border-top: 0.065em solid;
@@ -137,7 +137,7 @@ menclose {
     text-align: left;
     position: relative;
   }
-  
+
   .phasor-bottom {
     border-bottom: 0.067em solid;
     padding: 0.2em 0.2em 0.1em 0.6em;

--- a/src/cli/init/assets/render-mathtex.js
+++ b/src/cli/init/assets/render-mathtex.js
@@ -2,7 +2,7 @@ let eqns = document.querySelectorAll("script[type='math/tex']");
 for (let i=eqns.length-1; i>=0; i--) {
     let eqn = eqns[i];
     let src = eqn.text;
-    let d = eqn.closest('p') == null; 
+    let d = eqn.closest('p') == null;
     eqn.outerHTML = temml.renderToString(src, { displayMode: d });
 }
 

--- a/src/cli/init/content/about.smd
+++ b/src/cli/init/content/about.smd
@@ -4,7 +4,7 @@
 .author = "Sample Author",
 .layout = "index.shtml",
 .draft = false,
---- 
+---
 
 ## About Zine
 Zine is an MIT-licensed project created by [Loris Cro](https://kristoff.it) and
@@ -19,10 +19,10 @@ of authoring languages:
 - [SuperHTML](https://zine-ssg.io/docs/superhtml/) is the HTML templating
    language used by Zine. Unlike most `{{curly braced}}` templating languages,
    SuperHTML uses valid HTML syntax to express the templating logic, adding only
-   minor extensions to normal HTML.  
+   minor extensions to normal HTML.
    Thanks to this approach, it offers instant
    syntax checking and autoformatting via [a CLI tool](https://github.com/kristoff-it/superhtml) as well as Language Server support ([VScode Extension](https://marketplace.visualstudio.com/items?itemName=LorisCro.super)).
-  
+
   ># [NOTE]($block)
   >The correct file extension for SuperHTML templates is `.shtml`.
 
@@ -30,7 +30,7 @@ of authoring languages:
   that, instead of relying on inline HTML, offers new constructs for expressing
   content embeds without pulling into your content needless layouting concerns.
   A CLI tool and language server for SuperMD is in the works.
-  
+
   ># [NOTE]($block)
   >The correct file extension for SuperMD pages is `.smd`.
 
@@ -49,7 +49,7 @@ Here are some quicklinks related to Zine:
 - Official Website: https://zine-ssg.io/
 - Source Code: https://github.com/kristoff-it/zine/
 - Discord: https://discord.com/invite/B73sGxF
-  
+
 
 
 

--- a/src/cli/init/content/blog/first-post/index.smd
+++ b/src/cli/init/content/blog/first-post/index.smd
@@ -4,7 +4,7 @@
 .author = "Sample Author",
 .layout = "post.shtml",
 .draft = false,
---- 
+---
 
 This is a sample first post for your blog.
 

--- a/src/cli/init/content/blog/index.smd
+++ b/src/cli/init/content/blog/index.smd
@@ -3,13 +3,13 @@
 .date = @date("1990-01-01T00:00:00"),
 .author = "Sample Author",
 .layout = "blog.shtml",
-.alternatives = [{ 
+.alternatives = [{
     .name = "rss",
-    .layout = "blog.xml", 
+    .layout = "blog.xml",
     .output = "index.xml",
 }],
 .draft = false,
---- 
+---
 
 This page defines the blog section and lists all posts in it.
 
@@ -31,9 +31,9 @@ two versions: HTML for human readers, and XML for RSS readers.
 This is the SuperMD frontmatter code that defines the RSS feed:
 
 ```ziggy
-.alternatives = [{ 
+.alternatives = [{
     .name = "rss",
-    .layout = "rss.xml", 
+    .layout = "rss.xml",
     .output = "index.xml",
 }],
 ```

--- a/src/cli/init/content/blog/second-post.smd
+++ b/src/cli/init/content/blog/second-post.smd
@@ -4,7 +4,7 @@
 .author = "Sample Author",
 .layout = "post.shtml",
 .draft = false,
---- 
+---
 
 This second post is mainly here to show you that you can also create single file
 posts for convenience. The first post contains more interesting content.

--- a/src/cli/init/content/devlog/1989.smd
+++ b/src/cli/init/content/devlog/1989.smd
@@ -4,7 +4,7 @@
 .author = "Sample Author",
 .layout = "devlog.shtml",
 .draft = false,
---- 
+---
 []($section.id('about'))
 ## About this Devlog
 This is a non-exhaustive, curated list of changes meant to help users quickly see what has improved since they last checked.

--- a/src/cli/init/content/devlog/1990.smd
+++ b/src/cli/init/content/devlog/1990.smd
@@ -4,7 +4,7 @@
 .author = "Sample Author",
 .layout = "devlog.shtml",
 .draft = false,
---- 
+---
 []($section.id('about'))
 ## About this Devlog
 

--- a/src/cli/init/content/devlog/index.smd
+++ b/src/cli/init/content/devlog/index.smd
@@ -3,13 +3,13 @@
 .date = @date("1990-01-01T00:00:00"),
 .author = "Sample Author",
 .layout = "devlog-archive.shtml",
-.alternatives = [{ 
+.alternatives = [{
     .name = "rss",
-    .layout = "devlog.xml", 
+    .layout = "devlog.xml",
     .output = "index.xml",
 }],
 .draft = false,
---- 
+---
 
 This page lists all the devlog years that are present on this site.
 Note how the top navigation menu doesn't link to this page, but instead links
@@ -23,7 +23,7 @@ Devlog rotation ensures that you don't have a single page that grows
 indefinitely, eventually compromising your editing expreience and worsening your
 user's browsing experience. You can use any arbitrary policy (even deleting old
 entries if you are fine with having a more ephemeral devlog), but cutting them
-by year is a good default option. 
+by year is a good default option.
 
 When rotating a devlog all you have to do is create a new page with a newer
 date set in the frontmatter `date` field, and update the page description to let

--- a/src/cli/init/content/index.smd
+++ b/src/cli/init/content/index.smd
@@ -4,7 +4,7 @@
 .author = "Sample Author",
 .layout = "index.shtml",
 .draft = false,
---- 
+---
 
 This sample website showcases:
 
@@ -15,7 +15,7 @@ This sample website showcases:
   - `content/blog/index.smd`
   - `content/blog/first-post/index.smd`
   - `content/blog/second-post.smd`
-- A devlog 
+- A devlog
   - `content/devlog/index.smd`
   - `content/devlog/1990.smd`
   - `content/devlog/1989.smd`


### PR DESCRIPTION
I noticed trailing whitespaces throughout the `zine init` output. This MR cleans up the templates by removing it.