### PR TITLE
feat: mobile optimizations for init template

### DIFF
--- a/src/cli/init.zig
+++ b/src/cli/init.zig
@@ -44,6 +44,10 @@ pub fn init(io: Io, gpa: Allocator, args: []const []const u8) bool {
             .src = @embedFile("init/content/blog/second-post.smd"),
         },
         .{
+            .path = "content/blog/code-blocks.smd",
+            .src = @embedFile("init/content/blog/code-blocks.smd"),
+        },
+        .{
             .path = "content/devlog/index.smd",
             .src = @embedFile("init/content/devlog/index.smd"),
         },

--- a/src/cli/init/assets/style.css
+++ b/src/cli/init/assets/style.css
@@ -27,7 +27,8 @@ html {
 }
 
 body {
-  width: 800px;
+  max-width: 800px;
+  overflow-x: scroll;
   padding: 15px;
   display: flex;
   flex-direction: column;
@@ -45,6 +46,14 @@ nav {
   justify-content: left;
   font-size: 1.2em;
   margin-bottom: 20px;
+}
+
+pre {
+  overflow-x: scroll;
+}
+
+img {
+  max-width: 100vw;
 }
 
 .block {

--- a/src/cli/init/content/blog/code-blocks.smd
+++ b/src/cli/init/content/blog/code-blocks.smd
@@ -1,0 +1,36 @@
+---
+.title = "Third Post",
+.date = @date("1990-01-03T00:00:00"),
+.author = "Sample Author",
+.layout = "post.shtml",
+.draft = false,
+--- 
+
+Code blocks may be wider than the viewport on mobile. They'll scroll
+horizontally.
+
+```zig
+/// Shaper that uses CoreText.
+///
+/// CoreText shaping differs in subtle ways from HarfBuzz so it may result
+/// in inconsistent rendering across platforms. But it also fixes many
+/// issues (some macOS specific):
+///
+///   - Theta hat offset is incorrect in HarfBuzz but correct by default
+///     on macOS applications using CoreText. (See:
+///     https://github.com/harfbuzz/harfbuzz/discussions/4525)
+///
+///   - Hyphens (U+2010) can be synthesized by CoreText but not by HarfBuzz.
+///     See: https://github.com/mitchellh/ghostty/issues/1643
+///
+pub const Shaper = struct {
+    /// The allocated used for the feature list, font cache, and cell buf.
+    alloc: Allocator,
+
+    /// The string used for shaping the current run.
+    run_state: RunState,
+
+    /// CoreFoundation Dictionary which represents our font feature settings.
+    features: *macos.foundation.Dictionary,
+// ...
+```


### PR DESCRIPTION
I quickly ran into formatting issues on mobile where overflowing code blocks caused the page layout to be janky. My go-to solution for this case is horizontal scroll. It's pragmatic, not beautiful. Source-code won't fit in the horizontal space on a phone, so something needs to be done. I added `src/cli/init/content/blog/code-blocks.smd` to make this improvement clear but you may remove it if you get the point and don't want this in the init template. After all, you already have a code block on the home page. The actual code comes from Ghostty (MIT license). 

For `body`, I changed `width: 800px` to `max-width: 800px`. This is a best-practice. Prose should have a `max-width` so that lines don't get too long on wide displays. However, a fixed width causes the block to overflow smaller screens.

On the topic of mobile overflows, the image in "First Post: What's a Zine?" overflows on mobile, too. This is why I set `img` max-width to `100vw` ("viewport width").