### PR TITLE
improve rendering of html errors inside supermd

### DIFF
--- a/src/root.zig
+++ b/src/root.zig
@@ -1904,19 +1904,8 @@ fn printSuperMdErrors(
             break :blk h;
         } else "";
 
-        const msg = switch (err.kind) {
-            .scripty => |s| s.err,
-            else => "",
-        };
-
-        const tag_name = switch (err.kind) {
-            .html => |h| switch (h.tag) {
-                inline else => |_, t| @tagName(t),
-            },
-            else => @tagName(err.kind),
-        };
         std.debug.print(
-            \\{f}:{}:{}: [{s}] {s}
+            \\{f}:{}:{}: {f}
             \\|    {s}
             \\|    {s}
             \\
@@ -1924,8 +1913,7 @@ fn printSuperMdErrors(
             file.fmt(&v.string_table, &v.path_table, v.content_dir_path, ""),
             fm_lines + range.start.row,
             range.start.col,
-            tag_name,
-            msg,
+            fmtSuperMdError(err.kind),
             line_trim,
             highlight,
         });
@@ -1945,7 +1933,7 @@ fn printSuperMdErrors(
             build.mode.memory.errors.append(gpa, .{
                 .ref = "",
                 .msg = std.fmt.allocPrint(gpa,
-                    \\{f}:{}:{}: [{s}] {s}
+                    \\{f}:{}:{}: {f}
                     \\|    {s}
                     \\|    {s}
                     \\
@@ -1954,14 +1942,30 @@ fn printSuperMdErrors(
                     file.fmt(&v.string_table, &v.path_table, v.content_dir_path, ""),
                     fm_lines + range.start.row,
                     range.start.col,
-                    tag_name,
-                    msg,
+                    fmtSuperMdError(err.kind),
                     line_trim,
                     highlight,
                 }) catch fatal.oom(),
             }) catch fatal.oom();
         }
     }
+}
+
+const FormatSuperMdError = struct {
+    kind: supermd.Ast.Error.Kind,
+
+    pub fn format(err: FormatSuperMdError, w: *Io.Writer) Io.Writer.Error!void {
+        try w.print("[{t}]", .{err.kind});
+        switch (err.kind) {
+            .scripty => |s| try w.print(" {s}", .{s.err}),
+            .html => |h| try w.print(" {f}", .{h.tag.fmt("html")}),
+            else => {},
+        }
+    }
+};
+
+fn fmtSuperMdError(kind: supermd.Ast.Error.Kind) FormatSuperMdError {
+    return .{ .kind = kind };
 }
 
 pub fn fmtJoin(sep: u8, paths: []const []const u8) FormatJoin {

--- a/tests/content-scanning/page-analysis/snapshot.txt
+++ b/tests/content-scanning/page-analysis/snapshot.txt
@@ -19,11 +19,11 @@
 |                                               |
 *-----------------------------------------------*
 
-content/code.smd:17:3: [erroneous_end_tag] 
+content/code.smd:17:3: [html] erroneous end tag
 |    </span> wrong!
 |      ^^^^
 
-content/parse.smd:10:1: [html_is_forbidden] 
+content/parse.smd:10:1: [html_is_forbidden]
 |    <div>wrong block-level html</div>
 |    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 


### PR DESCRIPTION
Improves how error messages for [inline html](https://zine-ssg.io/docs/supermd/#inline-html) inside supermd are reported. This previously did not display the entire error message.

Before:
```
content/zls/releases/0.16.0.smd:104:14: [missing_required_attr] 
|    <source srcset="/static/0.16.0-zed-branching-types-dark.png" media="(prefers-color-scheme: dark)">
|     ^^^^^^
```

After:
```
content/zls/releases/0.16.0.smd:104:14: [html] missing required attribute(s): sizes
|    <source srcset="/static/0.16.0-zed-branching-types-dark.png" media="(prefers-color-scheme: dark)">
|     ^^^^^^
```
