### PR TITLE
build: support Zig 0.17.0-dev.1465 and NetBSD

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -146,9 +146,7 @@ pub fn serve(project: *std.Build, opts: Options) *std.Build.Step.Run {
 
 pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
-    const optimize = b.standardOptimizeOption(.{
-        // .preferred_optimize_mode = .fast,
-    });
+    const optimize = b.standardOptimizeOption(.{});
 
     const no_git_version = b.option(
         bool,
@@ -209,8 +207,6 @@ pub fn build(b: *std.Build) !void {
         "logging scopes to enable",
     ) orelse &.{};
 
-    const mode = .{ .target = target, .optimize = optimize };
-
     const options = blk: {
         const options = b.addOptions();
         try options.contents.print(b.allocator,
@@ -242,7 +238,10 @@ pub fn build(b: *std.Build) !void {
         .tracy = enable_tracy,
     }).module("superhtml");
 
-    const ziggy = b.dependency("ziggy", mode).module("ziggy");
+    const ziggy = b.dependency("ziggy", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("ziggy");
     const supermd = b.dependency("supermd", .{
         .target = target,
         .optimize = optimize,
@@ -252,12 +251,18 @@ pub fn build(b: *std.Build) !void {
     supermd.addImport("superhtml", superhtml);
     supermd.addImport("ziggy", ziggy);
 
-    const zeit = b.dependency("zeit", mode).module("zeit");
+    const zeit = b.dependency("zeit", .{
+        .target = target,
+        .optimize = optimize,
+    }).module("zeit");
     const syntax = b.dependency("flow_syntax", .{
         .target = target,
         .optimize = optimize,
     });
-    const ts = syntax.builder.dependency("tree_sitter", mode);
+    const ts = syntax.builder.dependency("tree_sitter", .{
+        .target = target,
+        .optimize = optimize,
+    });
     const treez = ts.module("treez");
 
     const mime = b.dependency("mime", .{
@@ -265,7 +270,10 @@ pub fn build(b: *std.Build) !void {
         .optimize = optimize,
     });
 
-    const wuffs = b.dependency("wuffs", mode);
+    const wuffs = b.dependency("wuffs", .{
+        .target = target,
+        .optimize = optimize,
+    });
     const translate_c = b.dependency("translate_c", .{
         .optimize = .fast,
     });
@@ -301,13 +309,6 @@ pub fn build(b: *std.Build) !void {
         b.installArtifact(shtml_docgen);
     }
 
-    const Translator = @import("translate_c").Translator;
-    const t: Translator = .init(translate_c, .{
-        .c_source_file = b.path("src/c.h"),
-        .target = target,
-        .optimize = optimize,
-    });
-
     switch (target.result.os.tag) {
         else => @panic("target must be added to build.zig"),
         .linux => {},
@@ -318,6 +319,13 @@ pub fn build(b: *std.Build) !void {
         },
         .windows => {},
         .macos => {
+            const Translator = @import("translate_c").Translator;
+            const t: Translator = .init(translate_c, .{
+                .c_source_file = b.path("src/c.h"),
+                .target = target,
+                .optimize = optimize,
+            });
+
             const frameworks = b.lazyDependency("frameworks", .{}) orelse return;
             zine_mod.addIncludePath(frameworks.path("include"));
             zine_mod.addFrameworkPath(frameworks.path("Frameworks"));
@@ -327,7 +335,6 @@ pub fn build(b: *std.Build) !void {
             t.addFrameworkPath(frameworks.path("Frameworks"));
             t.mod.addLibraryPath(frameworks.path("lib"));
             t.mod.linkFramework("CoreServices", .{});
-
             zine_mod.addImport("c", t.mod);
         },
     }

--- a/build.zig
+++ b/build.zig
@@ -59,7 +59,7 @@ pub const Options = struct {
     /// Debug settings for Zine.
     debug: struct {
         /// The optimization level to use when building Zine.
-        optimize: std.builtin.OptimizeMode = .ReleaseFast,
+        optimize: std.builtin.OptimizeMode = .fast,
 
         /// Logging scopes to enable.
         scopes: []const []const u8 = &.{},
@@ -147,7 +147,7 @@ pub fn serve(project: *std.Build, opts: Options) *std.Build.Step.Run {
 pub fn build(b: *std.Build) !void {
     const target = b.standardTargetOptions(.{});
     const optimize = b.standardOptimizeOption(.{
-        // .preferred_optimize_mode = .ReleaseFast,
+        // .preferred_optimize_mode = .fast,
     });
 
     const no_git_version = b.option(
@@ -267,7 +267,7 @@ pub fn build(b: *std.Build) !void {
 
     const wuffs = b.dependency("wuffs", mode);
     const translate_c = b.dependency("translate_c", .{
-        .optimize = .ReleaseFast,
+        .optimize = .fast,
     });
 
     const release = b.step("release", "Create release builds of Zine");
@@ -285,7 +285,7 @@ pub fn build(b: *std.Build) !void {
         .root_module = b.createModule(.{
             .root_source_file = b.path("src/docgen.zig"),
             .target = target,
-            .optimize = .Debug,
+            .optimize = .debug,
         }),
     });
     shtml_docgen.root_module.addImport("zeit", zeit);
@@ -311,6 +311,7 @@ pub fn build(b: *std.Build) !void {
     switch (target.result.os.tag) {
         else => @panic("target must be added to build.zig"),
         .linux => {},
+        .netbsd => {},
         .freebsd => {
             // only required for FreeBSD < 15
             // zine_exe.linkSystemLibrary("inotify");
@@ -374,7 +375,7 @@ fn setupSchemaCheck(
         types_mod.addImport("zine", zine_mod);
 
         const ziggy = @import("ziggy");
-        const check_step = ziggy.addTypeCheckStep(b, target, .Debug, types_mod, schema);
+        const check_step = ziggy.addTypeCheckStep(b, target, .debug, types_mod, schema);
         test_step.dependOn(check_step);
     }
 
@@ -386,7 +387,7 @@ fn setupSchemaCheck(
         types_mod.addImport("zine", zine_mod);
 
         const ziggy = @import("ziggy");
-        const check_step = ziggy.addTypeCheckStep(b, target, .Debug, types_mod, schema);
+        const check_step = ziggy.addTypeCheckStep(b, target, .debug, types_mod, schema);
         test_step.dependOn(check_step);
     }
 }
@@ -402,7 +403,7 @@ fn setupSnapshotTesting(
         .root_module = b.createModule(.{
             .root_source_file = b.path("build/camera.zig"),
             .target = target,
-            .optimize = .ReleaseFast,
+            .optimize = .fast,
         }),
     });
 
@@ -561,7 +562,7 @@ fn setupReleaseStep(
 
     for (targets) |t| {
         const target = b.resolveTargetQuery(t);
-        const optimize = .ReleaseFast;
+        const optimize = .fast;
 
         const tracy = b.dependency("tracy", .{ .enable = false });
         const scripty = b.dependency("scripty", .{
@@ -643,7 +644,7 @@ fn setupReleaseStep(
             .root_module = b.createModule(.{
                 .root_source_file = b.path("src/main.zig"),
                 .target = target,
-                .optimize = .ReleaseFast,
+                .optimize = .fast,
             }),
         });
 
@@ -662,6 +663,7 @@ fn setupReleaseStep(
         switch (target.result.os.tag) {
             else => @panic("target must be added to build.zig"),
             .linux => {},
+            .netbsd => {},
             .freebsd => {
                 // only required for FreeBSD < 15
                 // zine_exe_release.linkSystemLibrary("inotify");

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -2,15 +2,11 @@
     .name = .zine,
     .version = "0.13.1",
     .fingerprint = 0xa466bcb520a7eea2,
-    .minimum_zig_version = "0.17.0-dev.857+2b2b85c5f",
+    .minimum_zig_version = "0.17.0-dev.1471+ff10b90bc",
     .dependencies = .{
-        .lsp_kit = .{
-            .url = "git+https://github.com/zigtools/lsp-kit#dcbb8dd686d85a8f178a4389e730d41dd727b991",
-            .hash = "lsp_kit-0.1.0-bi_PL2UzDADxFRnnSjhhN7-ZTi9fDMom827yIp_ptc8l",
-        },
         .scripty = .{
-            .url = "git+https://github.com/kristoff-it/scripty#e23d9cdd1d246d3c4da246504649185c677ef3e9",
-            .hash = "scripty-0.1.0-LKK5O-sUAQD3oo3zhQHzZwYuTNVmvgaEvIxhu8JCfbI6",
+            .url = "git+https://github.com/kristoff-it/scripty#51a03222e9a125a65888a5df6e2a41e36c86ccd5",
+            .hash = "scripty-0.1.0-LKK5O-wUAQCZ2AQ8HKrYDny2POKmzmzzgaj392VVbVPg",
         },
         .tracy = .{
             .url = "git+https://github.com/kristoff-it/tracy#67d2d89e351048c76fc6d161e0ac09d8a831dc60",
@@ -21,8 +17,8 @@
             .hash = "mime-3.0.0-zwmL--0gAAByELrj57sRm2EFBRzjKLFrMgHQcs7sFZev",
         },
         .wuffs = .{
-            .url = "git+https://github.com/allyourcodebase/wuffs#5ea19ed8a0b78e3ab3d3d4d016d8b49e1af107a2",
-            .hash = "wuffs-0.4.0-alpha.9+3837.20240914-3CHJgZULAAARz_ehNESEv1jtLWo3q8nOTqNWH3-vADsK",
+            .url = "git+https://github.com/allyourcodebase/wuffs#364ba880b20ca1c9b94ee41b07738bc941cee275",
+            .hash = "wuffs-0.4.0-alpha.9+3837.20240914-3CHJgY8LAADueYEeHrj8cQs_rZQ0bDGsngrbgV7Z2LFt",
         },
         .frameworks = .{
             .url = "git+https://code.hexops.org/hexops/xcode-frameworks.git#8a1cfb373587ea4c9bb1468b7c986462d8d4e10e",
@@ -30,8 +26,8 @@
             .lazy = true,
         },
         .superhtml = .{
-            .url = "git+https://github.com/kristoff-it/superhtml#624a3eeadaf8f0cbe2e7d9d64ff621bc2d1c5d69",
-            .hash = "superhtml-0.7.0-Y7MdPDqHJgB3G-imgMY4mZF8ikIYJ3O-4hVNxBDP9Imp",
+            .url = "git+https://github.com/kristoff-it/superhtml#abd86c4ba995a37b0f0559801b32b35cde8bcef9",
+            .hash = "superhtml-0.7.0-Y7MdPPuSJgDIM8DNUQpLacP0BU9-0FousIeXbBOTKFrb",
         },
         .zeit = .{
             .url = "git+https://github.com/rockorager/zeit#ed64c36035fe44d6372c20cbcd447b0090687167",
@@ -42,16 +38,16 @@
             .hash = "flow_syntax-0.7.2-X8jOoSuMAQBanH2g5oW4BQmkW6s5AdfrRUE2byWrMVKp",
         },
         .ziggy = .{
-            .url = "git+https://github.com/kristoff-it/ziggy#06d7ce8df16974e0ee7f897db50784d84f6b9f32",
-            .hash = "ziggy-0.2.0-kTg8v6TvBwDaJXZ-bHaKizTGqzwLLESmrR2bjWCXDHUf",
+            .url = "git+https://github.com/kristoff-it/ziggy#be51f4dfd95590eae7c8674d660c1f16edef116b",
+            .hash = "ziggy-0.2.0-kTg8v53yBwCAN_CrgG3Y_ngWnkUb971-w-0LdZlE8hYJ",
         },
         .supermd = .{
-            .url = "git+https://github.com/kristoff-it/supermd#54be0dea412ff0a7ecc2424759acd1f03bc5c4ad",
-            .hash = "supermd-0.1.0-3Mco3Oq8WAD0AClKssDfKJ9qbLphnHjo3Q7H35C4pLih",
+            .url = "git+https://github.com/kristoff-it/supermd#f0551284a1d33184bf62ecf4ebbe153efe2128f2",
+            .hash = "supermd-0.1.0-3Mco3OO8WABy_SfXOHyqYaRZ2gTV_1Mtl5MLEao-ZeBY",
         },
         .translate_c = .{
-            .url = "git+https://codeberg.org/kristoff/translate-c?ref=0.17.x#c01b34d1e57010019d77ffef1dbc704af870a2eb",
-            .hash = "translate_c-0.0.0-Q_BUWrEwBwDpXYYuHRSbbDDpjB0NHXcusTe4yYJXzYlA",
+            .url = "git+https://codeberg.org/ziglang/translate-c#2a6613bcc09c74296d785e660fe98d2eb310d760",
+            .hash = "translate_c-0.0.0-Q_BUWjQ7BwAhlMt3Zf4l3Jw-y0_TOpJWgcK8rk4d0aWv",
         },
     },
     .paths = .{"."},

--- a/src/PathTable.zig
+++ b/src/PathTable.zig
@@ -48,7 +48,7 @@ pub const PathName = packed struct {
     pub const empty_name: String = @enumFromInt(0);
     pub const empty_path: Path = @enumFromInt(0);
     pub fn get(st: *const StringTable, pt: *const PathTable, src: []const u8) ?PathName {
-        if (builtin.mode == .Debug) {
+        if (builtin.mode == .debug) {
             assert(!std.mem.endsWith(u8, src, "/\\"));
             assert(st.get("") == empty_name);
             assert(pt.get(&.{}) == empty_path);

--- a/src/Variant.zig
+++ b/src/Variant.zig
@@ -420,7 +420,7 @@ fn scanContentDirInner(
                 .parent_section_id = dir_entry.parent_section,
                 .variant_id = variant_id,
             };
-            if (builtin.mode == .Debug) {
+            if (builtin.mode == .debug) {
                 index_page._debug = .{ .stage = .init(.scanned) };
             }
 
@@ -447,7 +447,7 @@ fn scanContentDirInner(
         const pages_old_len = pages.items.len;
         try pages.resize(gpa, pages_old_len + page_names.items.len);
 
-        if (builtin.mode == .Debug) {
+        if (builtin.mode == .debug) {
             const Ctx = struct {
                 st: *StringTable,
                 pub fn lessThan(ctx: @This(), lhs: String, rhs: String) bool {
@@ -494,7 +494,7 @@ fn scanContentDirInner(
                 .parent_section_id = current_section,
                 .variant_id = variant_id,
             };
-            if (builtin.mode == .Debug) {
+            if (builtin.mode == .debug) {
                 p._debug = .{ .stage = .init(.scanned) };
             }
 

--- a/src/cli/debug.zig
+++ b/src/cli/debug.zig
@@ -30,7 +30,7 @@ fn debugInner(
     const cfg, const base_dir_path = root.Config.load(io, gpa, .auto);
 
     worker.start(io);
-    defer if (builtin.mode == .Debug) worker.stopWaitAndDeinit(io);
+    defer if (builtin.mode == .debug) worker.stopWaitAndDeinit(io);
 
     // build_assets: *const std.StringArrayHashMapUnmanaged(BuildAsset) = .empty;
     const build = root.run(io, gpa, &cfg, .{
@@ -40,7 +40,7 @@ fn debugInner(
         .mode = .memory,
     }) catch fatal.oom();
 
-    defer if (builtin.mode == .Debug) build.deinit(io, gpa);
+    defer if (builtin.mode == .debug) build.deinit(io, gpa);
 
     for (build.variants, 0..) |*variant, vidx| {
         std.debug.print(

--- a/src/cli/release.zig
+++ b/src/cli/release.zig
@@ -13,7 +13,7 @@ pub fn release(io: Io, gpa: Allocator, args: []const []const u8) bool {
     const cfg, const base_dir_path = root.Config.load(io, gpa, .auto);
 
     worker.start(io);
-    defer if (builtin.mode == .Debug) worker.stopWaitAndDeinit(io);
+    defer if (builtin.mode == .debug) worker.stopWaitAndDeinit(io);
 
     const build = root.run(io, gpa, &cfg, .{
         .base_dir_path = base_dir_path,
@@ -27,7 +27,7 @@ pub fn release(io: Io, gpa: Allocator, args: []const []const u8) bool {
         },
     }) catch fatal.oom();
 
-    defer if (builtin.mode == .Debug) build.deinit(io, gpa);
+    defer if (builtin.mode == .debug) build.deinit(io, gpa);
 
     if (tracy.enable) {
         tracy.frameMarkNamed("waiting for tracy");

--- a/src/cli/serve.zig
+++ b/src/cli/serve.zig
@@ -26,6 +26,7 @@ const outside_html = @embedFile("serve/outside.html");
 const Watcher = switch (builtin.target.os.tag) {
     .linux => @import("serve/watcher/LinuxWatcher.zig"),
     .freebsd => @import("serve/watcher/LinuxWatcher.zig"),
+    .netbsd => @import("serve/watcher/NetBSDWatcher.zig"),
     .macos => @import("serve/watcher/MacosWatcher.zig"),
     .windows => @import("serve/watcher/WindowsWatcher.zig"),
     else => @compileError("unsupported platform"),
@@ -52,7 +53,7 @@ pub fn serve(io: Io, gpa: Allocator, args: []const []const u8) error{OutOfMemory
     const cmd: Command = try .parse(gpa, args);
 
     worker.start(io);
-    defer if (builtin.mode == .Debug) worker.stopWaitAndDeinit(io);
+    defer if (builtin.mode == .debug) worker.stopWaitAndDeinit(io);
 
     var buf: [64]ServeEvent = undefined;
     var channel: Channel(ServeEvent) = .init(&buf);
@@ -94,7 +95,7 @@ pub fn serve(io: Io, gpa: Allocator, args: []const []const u8) error{OutOfMemory
     }
 
     var dirs_to_watch: std.ArrayListUnmanaged([:0]const u8) = .empty;
-    defer if (builtin.mode == .Debug) dirs_to_watch.deinit(gpa);
+    defer if (builtin.mode == .debug) dirs_to_watch.deinit(gpa);
 
     try dirs_to_watch.appendSlice(
         gpa,

--- a/src/cli/serve/watcher/NetBSDWatcher.zig
+++ b/src/cli/serve/watcher/NetBSDWatcher.zig
@@ -1,0 +1,130 @@
+const NetBSDWatcher = @This();
+
+const std = @import("std");
+const Io = std.Io;
+const fatal = @import("../../../fatal.zig");
+const Debouncer = @import("../../serve.zig").Debouncer;
+const Allocator = std.mem.Allocator;
+
+const log = std.log.scoped(.watcher);
+
+const KEvent = extern struct {
+    ident: usize,
+    filter: i16,
+    flags: u16,
+    fflags: u32,
+    data: i64,
+    udata: usize,
+};
+
+const EVFILT_VNODE: i16 = -4;
+const EV_ADD: u16 = 0x0001;
+const EV_ENABLE: u16 = 0x0002;
+const EV_CLEAR: u16 = 0x0010;
+const NOTE_WRITE: u32 = 0x00000002;
+const NOTE_DELETE: u32 = 0x00000001;
+const NOTE_RENAME: u32 = 0x00000008;
+const NOTE_EXTEND: u32 = 0x00000004;
+
+const timespec = extern struct {
+    tv_sec: isize,
+    tv_nsec: isize,
+};
+
+extern "c" fn kqueue() c_int;
+extern "c" fn kevent(kq: c_int, changelist: ?[*]const KEvent, nchanges: c_int, eventlist: ?[*]KEvent, nevents: c_int, timeout: ?*const timespec) c_int;
+
+io: Io,
+gpa: Allocator,
+debouncer: *Debouncer,
+dir_paths: []const []const u8,
+
+kq: std.posix.fd_t = -1,
+
+pub fn init(
+    io_: Io,
+    gpa_: Allocator,
+    debouncer_: *Debouncer,
+    dir_paths_: []const []const u8,
+) NetBSDWatcher {
+    const kq = kqueue();
+    if (kq < 0) fatal.msg("error: unable to create kqueue", .{});
+    return .{
+        .io = io_,
+        .gpa = gpa_,
+        .debouncer = debouncer_,
+        .dir_paths = dir_paths_,
+        .kq = kq,
+    };
+}
+
+pub fn start(watcher: *NetBSDWatcher) !void {
+    const t = try std.Thread.spawn(.{}, NetBSDWatcher.listen, .{watcher});
+    t.detach();
+}
+
+pub fn listen(watcher: *NetBSDWatcher) !void {
+    var watch_fds: std.AutoHashMapUnmanaged(std.posix.fd_t, void) = .{};
+    defer watch_fds.deinit(watcher.gpa);
+
+    for (watcher.dir_paths) |dir_path| {
+        addWatch(watcher, dir_path, &watch_fds) catch |err| {
+            log.err("failed to watch {s}: {s}", .{ dir_path, @errorName(err) });
+        };
+    }
+
+    var events: [32]KEvent = undefined;
+    while (true) {
+        const nev = kevent(watcher.kq, null, 0, &events, @intCast(events.len), null);
+        if (nev < 0) {
+            log.err("kevent error", .{});
+            continue;
+        }
+
+        var changed = false;
+        for (events[0..@intCast(nev)]) |ev| {
+            if (ev.filter == EVFILT_VNODE) {
+                if (ev.fflags & NOTE_WRITE != 0 or
+                    ev.fflags & NOTE_DELETE != 0 or
+                    ev.fflags & NOTE_RENAME != 0 or
+                    ev.fflags & NOTE_EXTEND != 0)
+                {
+                    changed = true;
+                }
+            }
+        }
+        if (changed) {
+            watcher.debouncer.newEvent();
+        }
+    }
+}
+
+fn addWatch(
+    watcher: *NetBSDWatcher,
+    dir_path: []const u8,
+    watch_fds: *std.AutoHashMapUnmanaged(std.posix.fd_t, void),
+) !void {
+    const dir = try std.Io.Dir.cwd().openDir(watcher.io, dir_path, .{ .iterate = true });
+    defer dir.close(watcher.io);
+
+    const fd = dir.handle;
+    if (!watch_fds.contains(fd)) {
+        var ev: [1]KEvent = .{.{
+            .ident = @intCast(fd),
+            .filter = EVFILT_VNODE,
+            .flags = EV_ADD | EV_ENABLE | EV_CLEAR,
+            .fflags = NOTE_WRITE | NOTE_DELETE | NOTE_RENAME | NOTE_EXTEND,
+            .data = 0,
+            .udata = 0,
+        }};
+        _ = kevent(watcher.kq, @ptrCast(&ev), 1, null, 0, null);
+        try watch_fds.put(watcher.gpa, fd, {});
+    }
+}
+
+pub fn deinit(watcher: *NetBSDWatcher) void {
+    if (watcher.kq != -1) {
+        std.posix.close(watcher.kq);
+        watcher.kq = -1;
+    }
+}

--- a/src/context/Page.zig
+++ b/src/context/Page.zig
@@ -56,7 +56,7 @@ custom: ziggy.Dynamic = .{ .kv = .empty },
 
 /// Only present in debug builds to catch programming errors
 /// in the processing pipeline.
-_debug: if (builtin.mode != .Debug) void else struct {
+_debug: if (builtin.mode != .debug) void else struct {
     stage: std.atomic.Value(Stage),
     pub const Stage = enum(u8) { scanned, parsed, analyzed, rendered };
 } = undefined,
@@ -326,7 +326,7 @@ pub fn parse(
         ),
     }) catch unreachable;
 
-    if (builtin.mode == .Debug) {
+    if (builtin.mode == .debug) {
         const last = p._debug.stage.swap(.parsed, .acq_rel);
         assert(last == .scanned);
         tracy.messageCopy(path_bytes);

--- a/src/fatal.zig
+++ b/src/fatal.zig
@@ -4,7 +4,7 @@ const builtin = @import("builtin");
 
 pub fn msg(comptime fmt: []const u8, args: anytype) noreturn {
     std.debug.print(fmt, args);
-    if (builtin.mode == .Debug) std.debug.panic("\n\n(Zine debug stack trace)\n", .{});
+    if (builtin.mode == .debug) std.debug.panic("\n\n(Zine debug stack trace)\n", .{});
     std.process.exit(1);
 }
 

--- a/src/main.zig
+++ b/src/main.zig
@@ -44,7 +44,7 @@ pub fn main(init: std.process.Init) u8 {
     root.progress = std.Progress.start(io, .{ .draw_buffer = &root.progress_buf });
     defer root.progress.end();
 
-    if (builtin.mode == .Debug) {
+    if (builtin.mode == .debug) {
         std.debug.print(
             \\*-----------------------------------------------*
             \\|    WARNING: THIS IS A DEBUG BUILD OF ZINE     |
@@ -54,7 +54,7 @@ pub fn main(init: std.process.Init) u8 {
             \\|                                               |
             \\| To create a release build, run:               |
             \\|                                               |
-            \\|       zig build -Doptimize=ReleaseFast        |
+            \\|       zig build -Doptimize=fast               |
             \\|                                               |
             \\| If you're investigating a bug in Zine, then a |
             \\| debug build might turn confusing behavior     |

--- a/src/root.zig
+++ b/src/root.zig
@@ -626,7 +626,7 @@ pub fn run(
         // directory in this thread.
         // TODO: find a better moment for this work
         try build.scanTemplates(io, gpa, arena);
-        if (builtin.mode == .Debug) {
+        if (builtin.mode == .debug) {
             const Ctx = struct {
                 b: *Build,
                 pub fn lessThan(ctx: @This(), lid: usize, rid: usize) bool {

--- a/src/worker.zig
+++ b/src/worker.zig
@@ -119,7 +119,7 @@ pub fn start(io: Io) void {
 }
 
 pub fn stopWaitAndDeinit(io: Io) void {
-    if (builtin.mode != .Debug) return;
+    if (builtin.mode != .debug) return;
     if (builtin.single_threaded) addJob(io, .leave);
 
     for (threads) |_| addJob(io, .leave);
@@ -134,7 +134,7 @@ pub fn addJob(io: Io, job: Job) void {
         const continue_ = runOneJob(io, single_threaded_arena, job);
         _ = single_threaded_arena_state.reset(.retain_capacity);
 
-        if (builtin.mode == .Debug and !continue_) {
+        if (builtin.mode == .debug and !continue_) {
             single_threaded_arena_state.deinit();
         }
     } else {
@@ -246,7 +246,7 @@ fn analyzePage(
     defer zone.end();
 
     assert(page._parse.status == .parsed);
-    if (builtin.mode == .Debug) {
+    if (builtin.mode == .debug) {
         const last = page._debug.stage.swap(.analyzed, .monotonic);
         assert(last == .parsed);
     }
@@ -560,7 +560,7 @@ fn analyzeContent(
                                     p.ref,
                                 )) |path| break :blk path;
                                 log.debug("page link '{s}': path not found", .{p.ref});
-                                if (builtin.mode == .Debug) {
+                                if (builtin.mode == .debug) {
                                     var it = std.mem.tokenizeScalar(u8, p.ref, '/');
                                     while (it.next()) |c| {
                                         log.debug("'{s}' -> [{?d}]", .{

--- a/tests/content-scanning/collisions/snapshot.txt
+++ b/tests/content-scanning/collisions/snapshot.txt
@@ -6,7 +6,7 @@
 |                                               |
 | To create a release build, run:               |
 |                                               |
-|       zig build -Doptimize=ReleaseFast        |
+|       zig build -Doptimize=fast               |
 |                                               |
 | If you're investigating a bug in Zine, then a |
 | debug build might turn confusing behavior     |

--- a/tests/content-scanning/forbid-subsections/snapshot.txt
+++ b/tests/content-scanning/forbid-subsections/snapshot.txt
@@ -6,7 +6,7 @@
 |                                               |
 | To create a release build, run:               |
 |                                               |
-|       zig build -Doptimize=ReleaseFast        |
+|       zig build -Doptimize=fast               |
 |                                               |
 | If you're investigating a bug in Zine, then a |
 | debug build might turn confusing behavior     |

--- a/tests/content-scanning/frontmatter/snapshot.txt
+++ b/tests/content-scanning/frontmatter/snapshot.txt
@@ -6,7 +6,7 @@
 |                                               |
 | To create a release build, run:               |
 |                                               |
-|       zig build -Doptimize=ReleaseFast        |
+|       zig build -Doptimize=fast               |
 |                                               |
 | If you're investigating a bug in Zine, then a |
 | debug build might turn confusing behavior     |

--- a/tests/content-scanning/page-analysis/snapshot.txt
+++ b/tests/content-scanning/page-analysis/snapshot.txt
@@ -6,7 +6,7 @@
 |                                               |
 | To create a release build, run:               |
 |                                               |
-|       zig build -Doptimize=ReleaseFast        |
+|       zig build -Doptimize=fast               |
 |                                               |
 | If you're investigating a bug in Zine, then a |
 | debug build might turn confusing behavior     |

--- a/tests/content-scanning/simple/snapshot.txt
+++ b/tests/content-scanning/simple/snapshot.txt
@@ -6,7 +6,7 @@
 |                                               |
 | To create a release build, run:               |
 |                                               |
-|       zig build -Doptimize=ReleaseFast        |
+|       zig build -Doptimize=fast               |
 |                                               |
 | If you're investigating a bug in Zine, then a |
 | debug build might turn confusing behavior     |

--- a/tests/content-scanning/templates/snapshot.txt
+++ b/tests/content-scanning/templates/snapshot.txt
@@ -6,7 +6,7 @@
 |                                               |
 | To create a release build, run:               |
 |                                               |
-|       zig build -Doptimize=ReleaseFast        |
+|       zig build -Doptimize=fast               |
 |                                               |
 | If you're investigating a bug in Zine, then a |
 | debug build might turn confusing behavior     |

--- a/tests/drafts/simple/snapshot.txt
+++ b/tests/drafts/simple/snapshot.txt
@@ -6,7 +6,7 @@
 |                                               |
 | To create a release build, run:               |
 |                                               |
-|       zig build -Doptimize=ReleaseFast        |
+|       zig build -Doptimize=fast               |
 |                                               |
 | If you're investigating a bug in Zine, then a |
 | debug build might turn confusing behavior     |

--- a/tests/rendering/multi/snapshot.txt
+++ b/tests/rendering/multi/snapshot.txt
@@ -6,7 +6,7 @@
 |                                               |
 | To create a release build, run:               |
 |                                               |
-|       zig build -Doptimize=ReleaseFast        |
+|       zig build -Doptimize=fast               |
 |                                               |
 | If you're investigating a bug in Zine, then a |
 | debug build might turn confusing behavior     |

--- a/tests/rendering/simple/snapshot.txt
+++ b/tests/rendering/simple/snapshot.txt
@@ -6,7 +6,7 @@
 |                                               |
 | To create a release build, run:               |
 |                                               |
-|       zig build -Doptimize=ReleaseFast        |
+|       zig build -Doptimize=fast               |
 |                                               |
 | If you're investigating a bug in Zine, then a |
 | debug build might turn confusing behavior     |


### PR DESCRIPTION
- Update OptimizeMode enum values for Zig 0.17.0-dev.1465 API: .Debug → .debug, .ReleaseFast → .fast, .ReleaseSafe → .safe, .ReleaseSmall → .small across build.zig and all src/*.zig files
- Add .netbsd as a supported target in build.zig
- Add kqueue-based NetBSDWatcher for file watching on NetBSD